### PR TITLE
Add LDAP support for netbox chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.tgz
 .*.swp
 requirements.lock
+
+# IDE Settings
+.idea/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.6.12
 description: IP address management (IPAM) and data center infrastructure management (DCIM) tool
 icon: https://raw.githubusercontent.com/netbox-community/netbox/develop/docs/netbox_logo.png
 name: netbox
-version: 1.0.4
+version: 1.0.5

--- a/README.md
+++ b/README.md
@@ -47,114 +47,129 @@ PostgreSQL chart was upgraded from 5.x.x to 7.x.x, and Redis from 8.x.x to
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                             | Description                                                         | Default                                      |
-| --------------------------------------|---------------------------------------------------------------------|----------------------------------------------|
-| `replicaCount`                        | The desired number of NetBox pods                                   | `1`                                          |
-| `image.repository`                    | NetBox container image repository                                   | `netboxcommunity/netbox`                     |
-| `image.tag`                           | NetBox container image tag                                          | `v2.6.12`                                    |
-| `image.pullPolicy`                    | NetBox container image pull policy                                  | `IfNotPresent`                               |
-| `superuser.name`                      | Initial super-user account to create                                | `admin`                                      |
-| `superuser.email`                     | Email address for the initial super-user account                    | `admin@example.com`                          |
-| `superuser.password`                  | Password for the initial super-user account                         | `admin`                                      |
-| `superuser.apiToken`                  | API token created for the initial super-user account                | `0123456789abcdef0123456789abcdef01234567`   |
-| `skipStartupScripts`                  | Skip [netbox-docker startup scripts]                                | `true`                                       |
-| `allowedHosts`                        | List of valid FQDNs for this NetBox instance                        | `["*"]`                                      |
-| `admins`                              | List of admins to email about critical errors                       | `[]`                                         |
-| `banner.top`                          | Banner text to display at the top of every page                     | `""`                                         |
-| `banner.bottom`                       | Banner text to display at the bottom of every page                  | `""`                                         |
-| `banner.login`                        | Banner text to display on the login page                            | `""`                                         |
-| `basePath`                            | Base URL path if accessing NetBox within a directory                | `""`                                         |
-| `cacheTimeout`                        | Cached object time-to-live, in seconds                              | `900` (15 minutes)                           |
-| `cors.originAllowAll`                 | [CORS]: allow all origins                                           | `false`                                      |
-| `cors.originWhitelist`                | [CORS]: list of origins authorised to make cross-site HTTP requests | `[]`                                         |
-| `cors.originRegexWhitelist`           | [CORS]: list of regex strings matching authorised origins           | `[]`                                         |
-| `debug`                               | Enable NetBox debugging (NOT for production use)                    | `false`                                      |
-| `email.server`                        | SMTP server to use to send emails                                   | `localhost`                                  |
-| `email.port`                          | TCP port to connect to the SMTP server on                           | `25`                                         |
-| `email.username`                      | Optional username for SMTP authentication                           | `""`                                         |
-| `email.password`                      | Password for SMTP authentication (see also `existingSecret`)        | `""`                                         |
-| `email.timeout`                       | Timeout for SMTP connections, in seconds                            | `10`                                         |
-| `email.from`                          | Sender address for emails sent by NetBox                            | `""`                                         |
-| `enforceGlobalUnique`                 | Enforce unique IP space in the global table (not in a VRF)          | `false`                                      |
-| `exemptViewPermissions`               | A list of models to exempt from the enforcement of view permissions | `[]`                                         |
-| `logging`                             | Custom Django logging configuration                                 | `{}`                                         |
-| `loginRequired`                       | Permit only logged-in users to access NetBox                        | `false` (unauthenticated read-only access)   |
-| `maintenanceMode`                     | Display a "maintenance mode" banner on every page                   | `false`                                      |
-| `maxPageSize`                         | Maximum number of objects that can be returned by a single API call | `1000`                                       |
-| `napalm.username`                     | Username used by the NAPALM library to access network devices       | `""`                                         |
-| `napalm.password`                     | Password used by the NAPALM library (see also `existingSecret`)     | `""`                                         |
-| `napalm.timeout`                      | Timeout for NAPALM to connect to a device (in seconds)              | `30`                                         |
-| `napalm.args`                         | A dictionary of optional arguments to pass to NAPALM                | `{}`                                         |
-| `paginateCount`                       | The default number of objects to display per page in the web UI     | `50`                                         |
-| `preferIPv4`                          | Prefer devices' IPv4 address when determining their primary address | `false`                                      |
-| `metricsEnabled`                      | Expose Prometheus metrics at the `/metrics` HTTP endpoint           | `false`                                      |
-| `webhooksEnabled`                     | Enable NetBox's outgoing webhook functionality                      | `true`                                       |
-| `timeZone`                            | The time zone NetBox will use when dealing with dates and times     | `UTC`                                        |
-| `dateFormat`                          | Django date format for long-form date strings                       | `"N j, Y"`                                   |
-| `shortDateFormat`                     | Django date format for short-form date strings                      | `"Y-m-d"`                                    |
-| `timeFormat`                          | Django date format for long-form time strings                       | `"g:i a"`                                    |
-| `shortTimeFormat`                     | Django date format for short-form time strings                      | `"H:i:s"`                                    |
-| `dateTimeFormat`                      | Django date format for long-form date and time strings              | `"N j, Y g:i a"`                             |
-| `shortDateTimeFormat`                 | Django date format for short-form date and time strongs             | `"Y-m-d H:i"`                                |
-| `secretKey`                           | Django secret key used for sessions and password reset tokens       | `""` (generated)                             |
-| `existingSecret`                      | Use an existing Kubernetes `Secret` for secret values (see below)   | `""` (use individual chart values)           |
-| `postgresql.enabled`                  | Deploy PostgreSQL using bundled Bitnami PostgreSQL chart            | `true`                                       |
-| `postgresql.postgresqlUsername`       | Username to create for NetBox in bundled PostgreSQL instance        | `netbox`                                     |
-| `postgresql.postgresqlDatabase`       | Databaes to create for NetBox in bundled PostgreSQL instance        | `netbox`                                     |
-| `postgresql.*`                        | Values under this key are passed to the bundled PostgreSQL chart    | n/a                                          |
-| `externalDatabase.host`               | PostgreSQL host to use when `postgresql.enabled` is `false`         | `localhost`                                  |
-| `externalDatabase.port`               | Port number for external PostgreSQL                                 | `5432`                                       |
-| `externalDatabase.database`           | Database name for external PostgreSQL                               | `netbox`                                     |
-| `externalDatabase.username`           | Username for external PostgreSQL                                    | `netbox`                                     |
-| `externalDatabase.password`           | Password for external PostgreSQL (see also `existingSecret`)        | `""`                                         |
-| `externalDatabase.existingSecretName` | Fetch password for external PostgreSQL from a different `Secret`    | `""`                                         |
-| `externalDatabase.existingSecretKey`  | Key to fetch the password in the above `Secret`                     | `postgresql-password`                        |
-| `redisDatabase`                       | Redis database number used for NetBox webhooks queue                | `0`                                          |
-| `redisCacheDatabase`                  | Redis database number used for caching views, etc...                | `1`                                          |
-| `redisTimeout`                        | Redis connection timeout, in seconds                                | `300` (5 minutes)                            |
-| `redisSsl`                            | Enable SSL when connecting to Redis                                 | `false`                                      |
-| `redis.enabled`                       | Deploy Redis using bundled Bitnami Redis chart                      | `true`                                       |
-| `redis.*`                             | Values under this key are passed to the bundled Redis chart         | n/a                                          |
-| `externalRedis.host`                  | Redis host to use when `redis.enabled` is `false`                   | `localhost`                                  |
-| `externalRedis.port`                  | Port number for external Redis                                      | `6379`                                       |
-| `externalRedis.password`              | Password for external Redis (see also `existingSecret`)             | `""`                                         |
-| `externalRedis.existingSecretName`    | Fetch password for external Redis from a different `Secret`         | `""`                                         |
-| `externalRedis.existingSecretKey`     | Key to fetch the password in the above `Secret`                     | `redis-password`                             |
-| `imagePullSecrets`                    | List of `Secret` names containing private registry credentials      | `[]`                                         |
-| `nameOverride`                        | Override the application name (`netbox`) used throughout the chart  | `""`                                         |
-| `fullnameOverride`                    | Override the full name of resources created as part of the release  | `""`                                         |
-| `persistence.enabled`                 | Enable storage persistence for uploaded media (images)              | `true`                                       |
-| `persistence.existingClaim`           | Use an existing `PersistentVolumeClaim` instead of creating one     | `""`                                         |
-| `persistence.subPath`                 | Mount a sub-path of the volume into the container, not the root     | `""`                                         |
-| `persistence.storageClass`            | Set the storage class of the PVC (use `-` to disable provisioning)  | `""`                                         |
-| `persistence.accessMode`              | Access mode for the volume                                          | `ReadWriteOnce`                              |
-| `persistence.size`                    | Size of persistent volume to request                                | `1Gi`                                        |
-| `reportsPersistence.enabled`          | Enable storage persistence for NetBox reports                       | `false`                                      |
-| `reportsPersistence.existingClaim`    | Use an existing `PersistentVolumeClaim` instead of creating one     | `""`                                         |
-| `reportsPersistence.subPath`          | Mount a sub-path of the volume into the container, not the root     | `""`                                         |
-| `reportsPersistence.storageClass`     | Set the storage class of the PVC (use `-` to disable provisioning)  | `""`                                         |
-| `reportsPersistence.accessMode`       | Access mode for the volume                                          | `ReadWriteOnce`                              |
-| `reportsPersistence.size`             | Size of persistent volume to request                                | `1Gi`                                        |
-| `service.type`                        | Type of `Service` resource to create                                | `ClusterIP`                                  |
-| `service.port`                        | Port number for the service                                         | `80`                                         |
-| `ingress.enabled`                     | Create an `Ingress` resource for accessing NetBox                   | `false`                                      |
-| `ingress.annotations`                 | Extra annotations to apply to the `Ingress` resource                | `{}`                                         |
-| `ingress.hosts`                       | List of hosts and paths to map to the service (see `values.yaml`)   | `[{host:"chart-example.local",paths:["/"]}]` |
-| `ingress.tls`                         | TLS settings for the `Ingress` resource                             | `[]`                                         |
-| `resources`                           | Configure resource requests or limits for NetBox                    | `{}`                                         |
-| `nginx.image.repository`              | NGINX container image repository for proxy and static file serving  | `nginx`                                      |
-| `nginx.image.tag`                     | NGINX container image tag                                           | `1.16.0-alpine`                              |
-| `nginx.image.pullPolicy`              | NGINX container image pull policy                                   | `IfNotPresent`                               |
-| `nginx.resources`                     | Configure resource requests or limits for NGINX                     | `{}`                                         |
-| `nodeSelector`                        | Node labels for pod assignment                                      | `{}`                                         |
-| `tolerations`                         | Toleration labels for pod assignment                                | `[]`                                         |
-| `updateStrategy`                      | Configure deployment update strategy                                | `{}` (defaults to `RollingUpdate`)           |
-| `affinity`                            | Affinity settings for pod assignment                                | `{}`                                         |
-| `extraEnvs`                           | Additional environment variables to set in the NetBox container     | `[]`                                         |
-| `extraVolumeMounts`                   | Additional volumes to mount in the NetBox container                 | `[]`                                         |
-| `extraVolumes`                        | Additional volumes to reference in pods                             | `[]`                                         |
-| `extraContainers`                     | Additional sidecar containers to be added to pods                   | `[]`                                         |
-| `extraInitContainers`                 | Additional init containers to run before starting main containers   | `[]`                                         |
+| Parameter                                    | Description                                                         | Default                                      |
+| ---------------------------------------------|---------------------------------------------------------------------|----------------------------------------------|
+| `replicaCount`                               | The desired number of NetBox pods                                   | `1`                                          |
+| `image.repository`                           | NetBox container image repository                                   | `netboxcommunity/netbox`                     |
+| `image.tag`                                  | NetBox container image tag                                          | `v2.6.12`                                    |
+| `image.pullPolicy`                           | NetBox container image pull policy                                  | `IfNotPresent`                               |
+| `superuser.name`                             | Initial super-user account to create                                | `admin`                                      |
+| `superuser.email`                            | Email address for the initial super-user account                    | `admin@example.com`                          |
+| `superuser.password`                         | Password for the initial super-user account                         | `admin`                                      |
+| `superuser.apiToken`                         | API token created for the initial super-user account                | `0123456789abcdef0123456789abcdef01234567`   |
+| `skipStartupScripts`                         | Skip [netbox-docker startup scripts]                                | `true`                                       |
+| `allowedHosts`                               | List of valid FQDNs for this NetBox instance                        | `["*"]`                                      |
+| `admins`                                     | List of admins to email about critical errors                       | `[]`                                         |
+| `banner.top`                                 | Banner text to display at the top of every page                     | `""`                                         |
+| `banner.bottom`                              | Banner text to display at the bottom of every page                  | `""`                                         |
+| `banner.login`                               | Banner text to display on the login page                            | `""`                                         |
+| `basePath`                                   | Base URL path if accessing NetBox within a directory                | `""`                                         |
+| `cacheTimeout`                               | Cached object time-to-live, in seconds                              | `900` (15 minutes)                           |
+| `cors.originAllowAll`                        | [CORS]: allow all origins                                           | `false`                                      |
+| `cors.originWhitelist`                       | [CORS]: list of origins authorised to make cross-site HTTP requests | `[]`                                         |
+| `cors.originRegexWhitelist`                  | [CORS]: list of regex strings matching authorised origins           | `[]`                                         |
+| `debug`                                      | Enable NetBox debugging (NOT for production use)                    | `false`                                      |
+| `email.server`                               | SMTP server to use to send emails                                   | `localhost`                                  |
+| `email.port`                                 | TCP port to connect to the SMTP server on                           | `25`                                         |
+| `email.username`                             | Optional username for SMTP authentication                           | `""`                                         |
+| `email.password`                             | Password for SMTP authentication (see also `existingSecret`)        | `""`                                         |
+| `email.timeout`                              | Timeout for SMTP connections, in seconds                            | `10`                                         |
+| `email.from`                                 | Sender address for emails sent by NetBox                            | `""`                                         |
+| `enforceGlobalUnique`                        | Enforce unique IP space in the global table (not in a VRF)          | `false`                                      |
+| `exemptViewPermissions`                      | A list of models to exempt from the enforcement of view permissions | `[]`                                         |
+| `logging`                                    | Custom Django logging configuration                                 | `{}`                                         |
+| `loginRequired`                              | Permit only logged-in users to access NetBox                        | `false` (unauthenticated read-only access)   |
+| `maintenanceMode`                            | Display a "maintenance mode" banner on every page                   | `false`                                      |
+| `maxPageSize`                                | Maximum number of objects that can be returned by a single API call | `1000`                                       |
+| `napalm.username`                            | Username used by the NAPALM library to access network devices       | `""`                                         |
+| `napalm.password`                            | Password used by the NAPALM library (see also `existingSecret`)     | `""`                                         |
+| `napalm.timeout`                             | Timeout for NAPALM to connect to a device (in seconds)              | `30`                                         |
+| `napalm.args`                                | A dictionary of optional arguments to pass to NAPALM                | `{}`                                         |
+| `paginateCount`                              | The default number of objects to display per page in the web UI     | `50`                                         |
+| `preferIPv4`                                 | Prefer devices' IPv4 address when determining their primary address | `false`                                      |
+| `metricsEnabled`                             | Expose Prometheus metrics at the `/metrics` HTTP endpoint           | `false`                                      |
+| `webhooksEnabled`                            | Enable NetBox's outgoing webhook functionality                      | `true`                                       |
+| `timeZone`                                   | The time zone NetBox will use when dealing with dates and times     | `UTC`                                        |
+| `dateFormat`                                 | Django date format for long-form date strings                       | `"N j, Y"`                                   |
+| `shortDateFormat`                            | Django date format for short-form date strings                      | `"Y-m-d"`                                    |
+| `timeFormat`                                 | Django date format for long-form time strings                       | `"g:i a"`                                    |
+| `shortTimeFormat`                            | Django date format for short-form time strings                      | `"H:i:s"`                                    |
+| `dateTimeFormat`                             | Django date format for long-form date and time strings              | `"N j, Y g:i a"`                             |
+| `shortDateTimeFormat`                        | Django date format for short-form date and time strongs             | `"Y-m-d H:i"`                                |
+| `secretKey`                                  | Django secret key used for sessions and password reset tokens       | `""` (generated)                             |
+| `existingSecret`                             | Use an existing Kubernetes `Secret` for secret values (see below)   | `""` (use individual chart values)           |
+| `postgresql.enabled`                         | Deploy PostgreSQL using bundled Bitnami PostgreSQL chart            | `true`                                       |
+| `postgresql.postgresqlUsername`              | Username to create for NetBox in bundled PostgreSQL instance        | `netbox`                                     |
+| `postgresql.postgresqlDatabase`              | Databaes to create for NetBox in bundled PostgreSQL instance        | `netbox`                                     |
+| `postgresql.*`                               | Values under this key are passed to the bundled PostgreSQL chart    | n/a                                          |
+| `externalDatabase.host`                      | PostgreSQL host to use when `postgresql.enabled` is `false`         | `localhost`                                  |
+| `externalDatabase.port`                      | Port number for external PostgreSQL                                 | `5432`                                       |
+| `externalDatabase.database`                  | Database name for external PostgreSQL                               | `netbox`                                     |
+| `externalDatabase.username`                  | Username for external PostgreSQL                                    | `netbox`                                     |
+| `externalDatabase.password`                  | Password for external PostgreSQL (see also `existingSecret`)        | `""`                                         |
+| `externalDatabase.existingSecretName`        | Fetch password for external PostgreSQL from a different `Secret`    | `""`                                         |
+| `externalDatabase.existingSecretKey`         | Key to fetch the password in the above `Secret`                     | `postgresql-password`                        |
+| `redisDatabase`                              | Redis database number used for NetBox webhooks queue                | `0`                                          |
+| `redisCacheDatabase`                         | Redis database number used for caching views, etc...                | `1`                                          |
+| `redisTimeout`                               | Redis connection timeout, in seconds                                | `300` (5 minutes)                            |
+| `redisSsl`                                   | Enable SSL when connecting to Redis                                 | `false`                                      |
+| `redis.enabled`                              | Deploy Redis using bundled Bitnami Redis chart                      | `true`                                       |
+| `redis.*`                                    | Values under this key are passed to the bundled Redis chart         | n/a                                          |
+| `externalRedis.host`                         | Redis host to use when `redis.enabled` is `false`                   | `localhost`                                  |
+| `externalRedis.port`                         | Port number for external Redis                                      | `6379`                                       |
+| `externalRedis.password`                     | Password for external Redis (see also `existingSecret`)             | `""`                                         |
+| `externalRedis.existingSecretName`           | Fetch password for external Redis from a different `Secret`         | `""`                                         |
+| `externalRedis.existingSecretKey`            | Key to fetch the password in the above `Secret`                     | `redis-password`                             |
+| `imagePullSecrets`                           | List of `Secret` names containing private registry credentials      | `[]`                                         |
+| `nameOverride`                               | Override the application name (`netbox`) used throughout the chart  | `""`                                         |
+| `fullnameOverride`                           | Override the full name of resources created as part of the release  | `""`                                         |
+| `persistence.enabled`                        | Enable storage persistence for uploaded media (images)              | `true`                                       |
+| `persistence.existingClaim`                  | Use an existing `PersistentVolumeClaim` instead of creating one     | `""`                                         |
+| `persistence.subPath`                        | Mount a sub-path of the volume into the container, not the root     | `""`                                         |
+| `persistence.storageClass`                   | Set the storage class of the PVC (use `-` to disable provisioning)  | `""`                                         |
+| `persistence.accessMode`                     | Access mode for the volume                                          | `ReadWriteOnce`                              |
+| `persistence.size`                           | Size of persistent volume to request                                | `1Gi`                                        |
+| `reportsPersistence.enabled`                 | Enable storage persistence for NetBox reports                       | `false`                                      |
+| `reportsPersistence.existingClaim`           | Use an existing `PersistentVolumeClaim` instead of creating one     | `""`                                         |
+| `reportsPersistence.subPath`                 | Mount a sub-path of the volume into the container, not the root     | `""`                                         |
+| `reportsPersistence.storageClass`            | Set the storage class of the PVC (use `-` to disable provisioning)  | `""`                                         |
+| `reportsPersistence.accessMode`              | Access mode for the volume                                          | `ReadWriteOnce`                              |
+| `reportsPersistence.size`                    | Size of persistent volume to request                                | `1Gi`                                        |
+| `service.type`                               | Type of `Service` resource to create                                | `ClusterIP`                                  |
+| `service.port`                               | Port number for the service                                         | `80`                                         |
+| `ingress.enabled`                            | Create an `Ingress` resource for accessing NetBox                   | `false`                                      |
+| `ingress.annotations`                        | Extra annotations to apply to the `Ingress` resource                | `{}`                                         |
+| `ingress.hosts`                              | List of hosts and paths to map to the service (see `values.yaml`)   | `[{host:"chart-example.local",paths:["/"]}]` |
+| `ingress.tls`                                | TLS settings for the `Ingress` resource                             | `[]`                                         |
+| `resources`                                  | Configure resource requests or limits for NetBox                    | `{}`                                         |
+| `nginx.image.repository`                     | NGINX container image repository for proxy and static file serving  | `nginx`                                      |
+| `nginx.image.tag`                            | NGINX container image tag                                           | `1.16.0-alpine`                              |
+| `nginx.image.pullPolicy`                     | NGINX container image pull policy                                   | `IfNotPresent`                               |
+| `nginx.resources`                            | Configure resource requests or limits for NGINX                     | `{}`                                         |
+| `nodeSelector`                               | Node labels for pod assignment                                      | `{}`                                         |
+| `tolerations`                                | Toleration labels for pod assignment                                | `[]`                                         |
+| `updateStrategy`                             | Configure deployment update strategy                                | `{}` (defaults to `RollingUpdate`)           |
+| `affinity`                                   | Affinity settings for pod assignment                                | `{}`                                         |
+| `extraEnvs`                                  | Additional environment variables to set in the NetBox container     | `[]`                                         |
+| `extraVolumeMounts`                          | Additional volumes to mount in the NetBox container                 | `[]`                                         |
+| `extraVolumes`                               | Additional volumes to reference in pods                             | `[]`                                         |
+| `extraContainers`                            | Additional sidecar containers to be added to pods                   | `[]`                                         |
+| `extraInitContainers`                        | Additional init containers to run before starting main containers   | `[]`                                         |
+| `ldap.enabled`                               | Enable LDAP support for user management                             | `false`                                      |
+| `ldap.server_uri`                            | URI of the LDAP server(s) to query for users                        | `ldaps://dc.example.com`                     |
+| `ldap.bind_dn`                               | Distinguished Name (DN) of the user to login into the LDAP server   | `DN=user,OU=users,DC=example,DC=com`         |
+| `ldap.bind_password`                         | Password for the ldap.bind_dn account                               | `Passw0rd!`                                  |
+| `ldap.ignore_certificate_errors`             | Allow insecure connections when using TLS (ldaps://)                | `True`                                       |
+| `ldap.auth_user_search_scope`                | Can either be BASE, LEVEL, or SUBTREE                               | `SUBTREE`                                    |
+| `ldap.auth_group_search_scope`               | Can either be BASE, LEVEL, or SUBTREE                               | `SUBTREE`                                    |
+| `ldap.auth_user_search_base`                 | Location in LDAP directory to start search for users                | `OU=Users,DC=example,DC=com`                 |
+| `ldap.auth_group_search_base`                | Location in LDAP directory to start search for groups               | `OU=Groups,DC=example,DC=com`                |
+| `ldap.auth_user_dn_template`                 | If user DN can be derived from their username, no need to search    | `uid=%(user)s,ou=users..` (or better `None`) |
+| `ldap.auth_group_type`                       | If LDAP server supports nested groups use NestedGroupOfNamesType    | `GroupOfNamesType`                           |
+| `ldap.auth_require_group`                    | Base group a user must be member of for login permission            | `CN=netbox_users,DC=example,DC=com`          |
+| `ldap.auth_user_flags_by_group.is_active`    | Same as ldap.auth_require_group for login permission                | `CN=netbox_users,DC=example,DC=com`          |
+| `ldap.auth_user_flags_by_group.is_staff`     | Users can access the administration tools                           | `CN=staff,OU=groups,DC=example,DC=com`       |
+| `ldap.auth_user_falgs_by_group.is_superuser` | Users have superuser status with all permissions                    | `CN=superuser,OU=groups,DC=example,DC=com`   |
 
 [netbox-docker startup scripts]: https://github.com/netbox-community/netbox-docker/tree/master/startup_scripts
 [CORS]: https://github.com/ottoyiu/django-cors-headers

--- a/templates/_ldap_config.tpl.go
+++ b/templates/_ldap_config.tpl.go
@@ -17,7 +17,7 @@ AUTH_LDAP_BIND_PASSWORD = {{ .Values.ldap.bind_password | quote }}
 # Include this setting if you want to ignore certificate errors. This might be needed to accept a self-signed cert.
 # Note that this is a NetBox-specific setting which sets:
 #     ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
-LDAP_IGNORE_CERT_ERRORS = {{ .Values.ldap.ignore_certificate_errors }}
+LDAP_IGNORE_CERT_ERRORS = {{ .Values.ldap.ignore_certificate_errors | title }}
 
 
 # This search matches users with the sAMAccountName equal to the provided username. This is required if the user's
@@ -26,7 +26,7 @@ AUTH_LDAP_USER_SEARCH = LDAPSearch({{ .Values.ldap.auth_user_search_base | quote
                                     ldap.SCOPE_{{ .Values.ldap.auth_user_search_scope }}, "(sAMAccountName=%(user)s)")
 
 # If a user's DN is producible from their username, we don't need to search.
-AUTH_LDAP_USER_DN_TEMPLATE = {{ .Values.ldap.auth_user_dn_template | quote }}
+AUTH_LDAP_USER_DN_TEMPLATE = {{ eq .Values.ldap.auth_user_dn_template "None" | ternary "None" (.Values.ldap.auth_user_dn_template | quote) }}
 
 # You can map user attributes to Django attributes as so.
 AUTH_LDAP_USER_ATTR_MAP = {

--- a/templates/_ldap_config.tpl.go
+++ b/templates/_ldap_config.tpl.go
@@ -1,0 +1,63 @@
+{{- define "netbox.ldap_config" -}}
+import ldap
+from django_auth_ldap.config import LDAPSearch, {{ .Values.ldap.auth_group_type }}
+
+# Server URI
+AUTH_LDAP_SERVER_URI = {{ .Values.ldap.server_uri | quote}}
+
+# The following may be needed if you are binding to Active Directory.
+AUTH_LDAP_CONNECTION_OPTIONS = {
+    ldap.OPT_REFERRALS: 0
+}
+
+# Set the DN and password for the NetBox service account.
+AUTH_LDAP_BIND_DN = {{ .Values.ldap.bind_dn | quote}}
+AUTH_LDAP_BIND_PASSWORD = {{ .Values.ldap.bind_password | quote }}
+
+# Include this setting if you want to ignore certificate errors. This might be needed to accept a self-signed cert.
+# Note that this is a NetBox-specific setting which sets:
+#     ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+LDAP_IGNORE_CERT_ERRORS = {{ .Values.ldap.ignore_certificate_errors }}
+
+
+# This search matches users with the sAMAccountName equal to the provided username. This is required if the user's
+# username is not in their DN (Active Directory).
+AUTH_LDAP_USER_SEARCH = LDAPSearch({{ .Values.ldap.auth_user_search_scope | quote }},
+                                    ldap.SCOPE_SUBTREE, "(sAMAccountName=%(user)s)")
+
+# If a user's DN is producible from their username, we don't need to search.
+AUTH_LDAP_USER_DN_TEMPLATE = {{ .Values.ldap.auth_user_dn_template | quote }}
+
+# You can map user attributes to Django attributes as so.
+AUTH_LDAP_USER_ATTR_MAP = {
+    "first_name": "givenName",
+    "last_name": "sn",
+    "email": "mail"
+}
+
+# This search ought to return all groups to which the user belongs. django_auth_ldap uses this to determine group
+# hierarchy.
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch({{ .Values.ldap.auth_group_search_scope | quote }}, ldap.SCOPE_SUBTREE,
+                                    "(objectClass=group)")
+
+AUTH_LDAP_GROUP_TYPE = {{ .Values.ldap.auth_group_type }}()
+
+# Define a group required to login.
+AUTH_LDAP_REQUIRE_GROUP = {{ .Values.ldap.auth_require_group | quote }}
+
+# Mirror LDAP group assignments.
+AUTH_LDAP_MIRROR_GROUPS = True
+
+# Define special user types using groups. Exercise great caution when assigning superuser status.
+AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+    "is_active": {{ .Values.ldap.auth_user_flags_by_group.is_active | quote}},
+    "is_staff": {{ .Values.ldap.auth_user_flags_by_group.is_staff | quote}},
+    "is_superuser": {{ .Values.ldap.auth_user_flags_by_group.is_superuser | quote}}
+}
+
+# For more granular permissions, we can map LDAP groups to Django groups.
+AUTH_LDAP_FIND_GROUP_PERMS = True
+
+# Cache groups for one hour to reduce LDAP traffic
+AUTH_LDAP_CACHE_TIMEOUT = 3600
+{{ end }}

--- a/templates/_ldap_config.tpl.go
+++ b/templates/_ldap_config.tpl.go
@@ -22,8 +22,8 @@ LDAP_IGNORE_CERT_ERRORS = {{ .Values.ldap.ignore_certificate_errors }}
 
 # This search matches users with the sAMAccountName equal to the provided username. This is required if the user's
 # username is not in their DN (Active Directory).
-AUTH_LDAP_USER_SEARCH = LDAPSearch({{ .Values.ldap.auth_user_search_scope | quote }},
-                                    ldap.SCOPE_SUBTREE, "(sAMAccountName=%(user)s)")
+AUTH_LDAP_USER_SEARCH = LDAPSearch({{ .Values.ldap.auth_user_search_base | quote }},
+                                    ldap.SCOPE_{{ .Values.ldap.auth_user_search_scope }}, "(sAMAccountName=%(user)s)")
 
 # If a user's DN is producible from their username, we don't need to search.
 AUTH_LDAP_USER_DN_TEMPLATE = {{ .Values.ldap.auth_user_dn_template | quote }}
@@ -37,7 +37,7 @@ AUTH_LDAP_USER_ATTR_MAP = {
 
 # This search ought to return all groups to which the user belongs. django_auth_ldap uses this to determine group
 # hierarchy.
-AUTH_LDAP_GROUP_SEARCH = LDAPSearch({{ .Values.ldap.auth_group_search_scope | quote }}, ldap.SCOPE_SUBTREE,
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch({{ .Values.ldap.auth_group_search_base | quote }}, ldap.SCOPE_{{ .Values.ldap.auth_group_search_scope }},
                                     "(objectClass=group)")
 
 AUTH_LDAP_GROUP_TYPE = {{ .Values.ldap.auth_group_type }}()

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               readOnly: true
             {{- if or true .Values.ldap.enabled }}
             - name: ldap-config
-              mountPath: /etc/netbox/config/ldap_config.py
+              mountPath: /opt/netbox/netbox/netbox/ldap_config.py
               subPath: ldap_config.py
               readOnly: true
             {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,7 +26,11 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.ldap.enabled }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-ldap"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: SUPERUSER_NAME
@@ -51,7 +55,7 @@ spec:
               mountPath: /etc/netbox/config/configuration.py
               subPath: configuration.py
               readOnly: true
-            {{- if or true .Values.ldap.enabled }}
+            {{- if .Values.ldap.enabled }}
             - name: ldap-config
               mountPath: /opt/netbox/netbox/netbox/ldap_config.py
               subPath: ldap_config.py
@@ -132,11 +136,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "netbox.fullname" . }}
-        {{ if or true .Values.ldap.enabled }}
+        {{- if .Values.ldap.enabled }}
         - name: ldap-config
           secret:
             secretName: {{ include "netbox.fullname" . }}-ldap-config
-        {{ end }}
+        {{- end }}
         - name: secrets
           secret:
             secretName: {{ include "netbox.fullname" . }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -51,6 +51,12 @@ spec:
               mountPath: /etc/netbox/config/configuration.py
               subPath: configuration.py
               readOnly: true
+            {{- if or true .Values.ldap.enabled }}
+            - name: ldap-config
+              mountPath: /etc/netbox/config/ldap_config.py
+              subPath: ldap_config.py
+              readOnly: true
+            {{- end }}
             - name: config
               mountPath: /run/config/netbox
               readOnly: true
@@ -126,6 +132,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "netbox.fullname" . }}
+        {{ if or true .Values.ldap.enabled }}
+        - name: ldap-config
+          secret:
+            secretName: {{ include "netbox.fullname" . }}-ldap-config
+        {{ end }}
         - name: secrets
           secret:
             secretName: {{ include "netbox.fullname" . }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -19,3 +19,16 @@ data:
   superuser_password: {{ .Values.superuser.password | default (randAlphaNum 16) | b64enc }}
   superuser_api_token: {{ .Values.superuser.apiToken | default uuidv4 | b64enc }}
 {{- end -}}
+{{- if or true .Values.ldap.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netbox.fullname" . }}-ldap-config
+  labels:
+{{ include "netbox.labels" . | indent 4 }}
+type: Opaque
+data:
+  ldap_config.py: |-
+{{ include "netbox.ldap_config" . | b64enc | indent 4 }}
+{{- end -}}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -19,7 +19,7 @@ data:
   superuser_password: {{ .Values.superuser.password | default (randAlphaNum 16) | b64enc }}
   superuser_api_token: {{ .Values.superuser.apiToken | default uuidv4 | b64enc }}
 {{- end -}}
-{{- if or true .Values.ldap.enabled }}
+{{- if .Values.ldap.enabled }}
 ---
 apiVersion: v1
 kind: Secret

--- a/values.yaml
+++ b/values.yaml
@@ -329,7 +329,7 @@ ldap:
   server_uri: ldaps://dc.example.com
   bind_dn: "DN=user,OU=users,DC=example,DC=com"
   bind_password: "Passw0rd!"
-  ignore_certificate_errors: True
+  ignore_certificate_errors: "True"
   # The search scope can be of type BASE, LEVEL, or SUBTREE
   auth_user_search_scope: "SUBTREE"
   auth_group_search_scope: "SUBTREE"

--- a/values.yaml
+++ b/values.yaml
@@ -322,3 +322,20 @@ extraInitContainers: []
 #  - name: init-myservice
 #    image: busybox
 #    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+
+## LDAP configuration settings
+ldap:
+  enabled: false
+  server_uri: ldaps://dc.example.com
+  bind_dn: "DN=user,OU=users,DC=example,DC=com"
+  bind_password: "Passw0rd!"
+  ignore_certificate_errors: True
+  auth_user_search_scope: "ou=Users,dc=example,dc=com"
+  auth_user_dn_template: "uid=%(user)s,ou=users,dc=example,dc=com"
+  auth_group_search_scope: "dc=example,dc=com"
+  auth_group_type: "GroupOfNamesType"
+  auth_require_group: "CN=NETBOX_USERS,DC=example,DC=com"
+  auth_user_flags_by_group:
+    is_active: "cn=active,ou=groups,dc=example,dc=com"
+    is_staff: "cn=staff,ou=groups,dc=example,dc=com"
+    is_superuser: "cn=superuser,ou=groups,dc=example,dc=com"

--- a/values.yaml
+++ b/values.yaml
@@ -330,9 +330,14 @@ ldap:
   bind_dn: "DN=user,OU=users,DC=example,DC=com"
   bind_password: "Passw0rd!"
   ignore_certificate_errors: True
-  auth_user_search_scope: "ou=Users,dc=example,dc=com"
+  # The search scope can be of type BASE, LEVEL, or SUBTREE
+  auth_user_search_scope: "SUBTREE"
+  auth_group_search_scope: "SUBTREE"
+  auth_user_search_base: "ou=Users,dc=example,dc=com"
   auth_user_dn_template: "uid=%(user)s,ou=users,dc=example,dc=com"
-  auth_group_search_scope: "dc=example,dc=com"
+  auth_group_search_base: "dc=example,dc=com"
+  # The group type can be of values GroupOfNamesType and NestedGroupOfNamesType
+  # The Nested type is needed for Windows Domain Controllers
   auth_group_type: "GroupOfNamesType"
   auth_require_group: "CN=NETBOX_USERS,DC=example,DC=com"
   auth_user_flags_by_group:

--- a/values.yaml
+++ b/values.yaml
@@ -324,23 +324,43 @@ extraInitContainers: []
 #    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
 
 ## LDAP configuration settings
+# enabled       - toggle to en- or disable LDAP support for netbox
+# server_uri    - contains an URL that points to a LDAP server
+#                 can begin with ldap:// or ldaps://
+# bind_dn       - the path to the user for netbox to login into the LDAP server
+# bind_password - the password for the above user
+# ignore_certificate_errors - toggle for strict checking of TLS certificates when
+#                             using the ldaps:// scheme in the server_uri setting
+#                             with selfsigned or custom certificate authorities that
+#                             cannot be verified by the container. Use with caution!
 ldap:
   enabled: false
-  server_uri: ldaps://dc.example.com
+  server_url: ldaps://dc.example.com
   bind_dn: "DN=user,OU=users,DC=example,DC=com"
   bind_password: "Passw0rd!"
   ignore_certificate_errors: "True"
-  # The search scope can be of type BASE, LEVEL, or SUBTREE
+
+  # The search scope can be of type BASE, LEVEL, or SUBTREE. This determines if the LDAP
+  # search request will be recursive (SUBTREE), at the OU level (LEVEL) or the specific
+  # entry (BASE) of the search base will be considered.
   auth_user_search_scope: "SUBTREE"
   auth_group_search_scope: "SUBTREE"
-  auth_user_search_base: "ou=Users,dc=example,dc=com"
-  auth_user_dn_template: "uid=%(user)s,ou=users,dc=example,dc=com"
-  auth_group_search_base: "dc=example,dc=com"
+
+  # Search bases for users and groups in directory tree
+  auth_user_search_base: "OU=Users,DC=example,DC=com"
+  auth_group_search_base: "OU=Groups,DC=example,DC=com"
+
+  # If the user DN can be derived from their username no template is necessary
+  # and a value of None can and should be used
+  auth_user_dn_template: "uid=%(user)s,OU=users,DC=example,DC=com"
+
   # The group type can be of values GroupOfNamesType and NestedGroupOfNamesType
   # The Nested type is needed for Windows Domain Controllers
   auth_group_type: "GroupOfNamesType"
-  auth_require_group: "CN=NETBOX_USERS,DC=example,DC=com"
+
+  # Permission groups for netbox users
+  auth_require_group: "CN=active,OU=groups,DC=example,DC=com"
   auth_user_flags_by_group:
-    is_active: "cn=active,ou=groups,dc=example,dc=com"
-    is_staff: "cn=staff,ou=groups,dc=example,dc=com"
-    is_superuser: "cn=superuser,ou=groups,dc=example,dc=com"
+    is_active: "cn=active,OU=groups,DC=example,DC=com"
+    is_staff: "cn=staff,OU=groups,DC=example,DC=com"
+    is_superuser: "cn=superuser,OU=groups,DC=example,DC=com"


### PR DESCRIPTION
Added a secrets template with the content of the ldap_config.py file and
mounted it into the netbox pod.

The values.yaml got extended for the necessary keys described in the
documentation.

Chart version updated to 1.0.5

Addresses #6 

Signed-off-by: Marcus Franke <marcus.franke@gmail.com>