### PR TITLE
Add service annotations

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "netbox.fullname" . }}
   labels:
 {{ include "netbox.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "netbox.fullname" . }}
   labels:
 {{ include "netbox.labels" . | indent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -246,6 +246,10 @@ reportsPersistence:
   size: 1Gi
 
 service:
+  annotations: {}
+    # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <acm_cert_arn>
+    # service.beta.kubernetes.io/aws-load-balancer-ssl-ports: http
   type: ClusterIP
   port: 80
 


### PR DESCRIPTION
I'd like to be able to set annotations on the kubernetes service, so that I can automatically set AWS LB listener details as described in [this AWS doc](https://aws.amazon.com/premiumsupport/knowledge-center/terminate-https-traffic-eks-acm/)

This change just propogates service annotations set in values.yaml through to the service.yaml