### PR TITLE
Add support to adding arbitrary backends

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -37,10 +37,7 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: http
           {{- else }}
-          - path: {{ .path }}
-            backend:
-              serviceName: {{ .serviceName | default $fullName }}
-              servicePort: {{ .servicePort | default "http" }}
+          - {{ . | toYaml | indent 12 | trim }}
           {{- end }}
           {{- end }}
     {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -31,10 +31,17 @@ spec:
       http:
         paths:
           {{- range .paths }}
+          {{- if kindIs "string" . }}
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
+          {{- else }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName | default $fullName }}
+              servicePort: {{ .servicePort | default "http" }}
+          {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -379,9 +379,16 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
+        # You can manually specify the service name and service port if required.
+        # (For exemple if you're using AWS ALB ingress controller and want to set up automatic SSL redirect (https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/#redirect-traffic-from-http-to-https))
+        # - path: /*
+        #  serviceName: ssl-redirect
+        #  servicePort: use-annotation
+        
+        # Or you can let the template to set it for you.
+        # Both rules can be combined.
         # NB: You may also want to set the basePath above
-        - /
-
+        - path: /
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/values.yaml
+++ b/values.yaml
@@ -379,16 +379,20 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
-        # You can manually specify the service name and service port if required.
-        # (For exemple if you're using AWS ALB ingress controller and want to set up automatic SSL redirect (https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/#redirect-traffic-from-http-to-https))
+        # You can manually specify the service name and service port if
+        # required. This could be useful if for exemple you are using the AWS
+        # ALB Ingress Controller and want to set up automatic SSL redirect.
+        # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/#redirect-traffic-from-http-to-https
         # - path: /*
-        #  serviceName: ssl-redirect
-        #  servicePort: use-annotation
-        
-        # Or you can let the template to set it for you.
-        # Both rules can be combined.
+        #   backend:
+        #     serviceName: ssl-redirect
+        #     servicePort: use-annotation
+        #
+        # Or you can let the template set it for you.
+        # Both types of rule can be combined.
         # NB: You may also want to set the basePath above
         - /
+
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/values.yaml
+++ b/values.yaml
@@ -388,7 +388,7 @@ ingress:
         # Or you can let the template to set it for you.
         # Both rules can be combined.
         # NB: You may also want to set the basePath above
-        - path: /
+        - /
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Hello,

This PR allow users to configure additionally paths with arbitrary backend.
The main use case is to support ALB ingress controller redirect from HTTP to HTTPS as specified in this [AWS documentation](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/#redirect-traffic-from-http-to-https)

The values configuration for this scenario is
```yaml
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: alb
    alb.ingress.kubernetes.io/scheme: internal
    alb.ingress.kubernetes.io/backend-protocol: "HTTP"
    alb.ingress.kubernetes.io/healthcheck-path: '/login/'
    alb.ingress.kubernetes.io/success-codes: '200'
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
    alb.ingress.kubernetes.io/certificate-arn: redacted
    external-dns.alpha.kubernetes.io/hostname: redacted
  hosts:
    - host: redacted
      paths:
        - path: /*
          serviceName: ssl-redirect
          servicePort: use-annotation
        - path: /*
```

helm template output
```yaml
# Source: netbox/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: netbox
  labels:
    helm.sh/chart: netbox-2.3.0
    app.kubernetes.io/name: netbox
    app.kubernetes.io/instance: netbox
    app.kubernetes.io/version: "v2.9.3"
    app.kubernetes.io/managed-by: Helm
  annotations:
    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig":
      { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
    alb.ingress.kubernetes.io/backend-protocol: HTTP
    alb.ingress.kubernetes.io/certificate-arn: redacted
    alb.ingress.kubernetes.io/healthcheck-path: /login/
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
    alb.ingress.kubernetes.io/scheme: internal
    alb.ingress.kubernetes.io/success-codes: "200"
    external-dns.alpha.kubernetes.io/hostname: redacted
    kubernetes.io/ingress.class: alb
spec:
  rules:
    - host: redacted
      http:
        paths:
          - path: /*
            backend:
              serviceName: ssl-redirect
              servicePort: use-annotation
          - path: /*
             backend:
              serviceName: netbox
              servicePort: http
```

There is no breaking changes in the values.yaml as both "old" and "new" syntax is supported