### PR TITLE
Add the ability to use selectors for media & reports PV

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,14 @@ The following table lists the configurable parameters for this chart and their d
 | `persistence.existingClaim`                     | Use an existing `PersistentVolumeClaim` instead of creating one     | `""`                                         |
 | `persistence.subPath`                           | Mount a sub-path of the volume into the container, not the root     | `""`                                         |
 | `persistence.storageClass`                      | Set the storage class of the PVC (use `-` to disable provisioning)  | `""`                                         |
+| `persistence.selector`                          | Set the selector for PVs, if desired                                | `{}`                                         |
 | `persistence.accessMode`                        | Access mode for the volume                                          | `ReadWriteOnce`                              |
 | `persistence.size`                              | Size of persistent volume to request                                | `1Gi`                                        |
 | `reportsPersistence.enabled`                    | Enable storage persistence for NetBox reports                       | `false`                                      |
 | `reportsPersistence.existingClaim`              | Use an existing `PersistentVolumeClaim` instead of creating one     | `""`                                         |
 | `reportsPersistence.subPath`                    | Mount a sub-path of the volume into the container, not the root     | `""`                                         |
 | `reportsPersistence.storageClass`               | Set the storage class of the PVC (use `-` to disable provisioning)  | `""`                                         |
+| `reportsPersistence.selector`                   | Set the selector for PVs, if desired                                | `{}`                                         |
 | `reportsPersistence.accessMode`                 | Access mode for the volume                                          | `ReadWriteOnce`                              |
 | `reportsPersistence.size`                       | Size of persistent volume to request                                | `1Gi`                                        |
 | `podAnnotations`                                | Additional annotations for NetBox pods                              | `{}`                                         |

--- a/templates/pvc-media.yaml
+++ b/templates/pvc-media.yaml
@@ -18,4 +18,7 @@ spec:
   storageClassName: {{ .Values.persistence.storageClass | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.persistence.selector }}
+  selector: {{ toYaml .Values.persistence.selector | nindent 4 }}
+{{- end }}
 {{- end -}}

--- a/templates/pvc-reports.yaml
+++ b/templates/pvc-reports.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "netbox.fullname" . }}-reports
+  name: {{ printf "%s-reports" (include "netbox.fullname" .) }}
   labels:
 {{ include "netbox.labels" . | indent 4 }}
 spec:
@@ -17,5 +17,8 @@ spec:
 {{- else }}
   storageClassName: {{ .Values.reportsPersistence.storageClass | quote }}
 {{- end }}
+{{- end }}
+{{- if .Values.reportsPersistence.selector }}
+  selector: {{ toYaml .Values.reportsPersistence.selector | nindent 4 }}
 {{- end }}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -318,6 +318,11 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   storageClass: ""
+  ## Persistent Volume Selector
+  ## if enabled, define any Selectors for choosing existing Persistent Volumes here
+  # selector:
+  #   matchLabel:
+  #     netbox-storage: media
   accessMode: ReadWriteOnce
   ##
   ## Persistant storage size request
@@ -339,6 +344,11 @@ reportsPersistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   storageClass: ""
+  ## Persistent Volume Selector
+  ## if enabled, define any Selectors for choosing existing Persistent Volumes here
+  # selector:
+  #   matchLabel:
+  #     netbox-storage: reports
   accessMode: ReadWriteOnce
   ##
   ## Persistant storage size request


### PR DESCRIPTION
Hello altogether,

as it was useful in our case, we've added selectors to media & reports-Volumes.
This way any k8s-installation without PersistentVolume-provisioners can be used more easily.
