### PR TITLE
Add Netbox worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The following table lists the configurable parameters for this chart and their d
 | `extraVolumes`                                  | Additional volumes to reference in pods                             | `[]`                                         |
 | `extraContainers`                               | Additional sidecar containers to be added to pods                   | `[]`                                         |
 | `extraInitContainers`                           | Additional init containers to run before starting main containers   | `[]`                                         |
+| `worker`                                        | Worker specific variables. Most global variables also apply here.   | *see `values.yaml`*                          |
 
 [netbox-docker startup scripts]: https://github.com/netbox-community/netbox-docker/tree/master/startup_scripts
 [CORS]: https://github.com/ottoyiu/django-cors-headers

--- a/templates/deployment_worker.yaml
+++ b/templates/deployment_worker.yaml
@@ -1,30 +1,28 @@
-# Netbox & Nginx
+# Netbox Worker
+{{- if .Values.worker.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "netbox.fullname" . }}
+  name: {{ include "netbox.fullname" . }}-worker
   labels:
     {{- include "netbox.labels" . | nindent 4 }}
 spec:
-{{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+{{- if not .Values.worker.autoscaling.enabled }}
+  replicas: {{ .Values.worker.replicaCount }}
 {{- end }}
   selector:
     matchLabels:
       {{- include "netbox.selectorLabels" . | nindent 6 }}
-  {{ if .Values.updateStrategy -}}
+  {{ if .Values.worker.updateStrategy -}}
   strategy:
-    {{- toYaml .Values.updateStrategy | nindent 4 }}
+    {{- toYaml .Values.worker.updateStrategy | nindent 4 }}
   {{ end -}}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if (not .Values.existingSecret) }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- with .Values.podAnnotations }}
+        {{- with .Values.worker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
@@ -36,36 +34,23 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "netbox.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-worker
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.worker.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command:
+            - python3
+            - manage.py
+            - rqworker
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: SUPERUSER_NAME
-              value: {{ .Values.superuser.name | quote }}
-            - name: SUPERUSER_EMAIL
-              value: {{ .Values.superuser.email | quote }}
             - name: SKIP_STARTUP_SCRIPTS
-              value: {{ .Values.skipStartupScripts | quote }}
+              value: 'True'
             {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          ports:
-            - name: netbox
-              containerPort: 8001
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /{{ .Values.basePath }}login/
-              port: netbox
-              {{- if (not (eq (index .Values.allowedHosts 0) "*")) }}
-              httpHeaders:
-                - name: Host
-                  value: {{ (index .Values.allowedHosts 0) | quote }}
-              {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/netbox/config/configuration.py
@@ -87,8 +72,6 @@ spec:
               mountPath: /opt/netbox/netbox/reports
               subPath: {{ .Values.reportsPersistence.subPath | default "" | quote }}
             {{- end }}
-            - name: static
-              mountPath: /opt/netbox/netbox/static
             {{- if or .Values.postgresql.enabled .Values.externalDatabase.existingSecretName }}
             - name: db-secret
               mountPath: /run/secrets/database
@@ -110,55 +93,17 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
-            - name: secrets
-              mountPath: /run/secrets/superuser_password
-              subPath: superuser_password
-              readOnly: true
-            - name: secrets
-              mountPath: /run/secrets/superuser_api_token
-              subPath: superuser_api_token
-              readOnly: true
-            {{- with .Values.extraVolumeMounts }}
+            {{- with .Values.worker.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if .Values.resources }}
+          {{- if .Values.worker.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.worker.resources | nindent 12 }}
           {{- end }}
-        - name: nginx
-          securityContext:
-            {{- toYaml .Values.nginx.securityContext | nindent 12 }}
-          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
-          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
-          command: [nginx, -g, 'daemon off;']
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /{{ .Values.basePath }}
-              port: http
-          volumeMounts:
-            - name: config
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
-              readOnly: true
-            - name: static
-              mountPath: /opt/netbox/netbox/static
-              readOnly: true
-            - name: nginx-cache
-              mountPath: /var/cache/nginx
-            - name: nginx-run
-              mountPath: /run
-          {{- if .Values.nginx.resources }}
-          resources:
-            {{- toYaml .Values.nginx.resources | nindent 12 }}
-          {{- end }}
-        {{- with .Values.extraContainers }}
+        {{- with .Values.worker.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.extraInitContainers }}
+      {{- with .Values.worker.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -176,11 +121,6 @@ spec:
         - name: netbox-tmp
           emptyDir:
             medium: Memory
-        - name: nginx-cache
-          emptyDir: {}
-        - name: nginx-run
-          emptyDir:
-            medium: Memory
         - name: media
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
@@ -193,8 +133,6 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "netbox.fullname" .)) }}
         {{- end }}
-        - name: static
-          emptyDir: {}
         {{- if or .Values.postgresql.enabled .Values.externalDatabase.existingSecretName }}
         - name: db-secret
           secret:
@@ -223,15 +161,16 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,4 +1,8 @@
+# contains all HorizontalPodAutoscaler
+
+# Netbox & Nginx
 {{- if .Values.autoscaling.enabled }}
+---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -24,5 +28,36 @@ spec:
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}
+
+# Netbox Worker
+{{- if and .Values.worker.enabled .Values.worker.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "netbox.fullname" . }}-worker
+  labels:
+    {{- include "netbox.worker.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "netbox.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -472,3 +472,85 @@ extraInitContainers: []
 #  - name: init-myservice
 #    image: busybox
 #    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+
+# Worker for Netbox
+# Only required for Netbox Jobs, e.g. Webhooks
+worker:
+  enabled: true
+
+  replicaCount: 1
+
+  podAnnotations: {}
+
+  podSecurityContext:
+    # fsGroup: 1000
+    runAsNonRoot: true
+    # runAsUser: 1000
+    # runAsGroup: 1000
+
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  resources: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  updateStrategy: {}
+    # type: RollingUpdate
+
+  affinity: {}
+
+  ## Additional environment variables to set
+  extraEnvs: []
+  #  - name: FOO
+  #    valueFrom:
+  #      secretKeyRef:
+  #        key: FOO
+  #        name: secret-resource
+
+  ## Additional volumes to mount
+  extraVolumeMounts: []
+  #  - name: extra-volume
+  #    mountPath: /run/secrets/super-secret
+  #    readOnly: true
+
+  extraVolumes: []
+  #  - name: extra-volume
+  #    secret:
+  #      secretName: super-secret
+
+  ## Additional containers to be added to the NetBox pod.
+  extraContainers: []
+  #  - name: my-sidecar
+  #    image: nginx:latest
+
+  ## Containers which are run before the NetBox containers are started.
+  extraInitContainers: []
+  #  - name: init-myservice
+  #    image: busybox
+  #    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']


### PR DESCRIPTION
Hello altogether,

Netbox comes with a differenciation between Logic & UI and its workers, those who execute e.g. webhooks.

Therefore we've added a simple copy of the common Netbox deployment, removed Nginx and other things that are not required and changed command attribute to start `rqworker`.

We've also copied the HorizontalPodAutoscaler for this deployment, so usage can be fitted according to anyones requirements.

Source: https://github.com/netbox-community/netbox-docker/blob/release/docker-compose.yml#L21
Partly fixes #17 