### PR TITLE
Added LDAP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.autoCreateUser`                     | Enables the automatic creation of new users                         | `true`                                       |
 | `remoteAuth.defaultGroups`                      | A list of groups to assign to newly created users                   | `[]`                                         |
 | `remoteAuth.defaultPermissions`                 | A list of permissions to assign newly created users                 | `{}`                                         |
+| `remoteAuth.ldap.serverUri`                     | see [django-auth-ldap](https://django-auth-ldap.readthedocs.io)     | `""`                                         |
+| `remoteAuth.ldap.startTls`                      | if StarTLS should be used                                           | *see values.yaml*                            |
+| `remoteAuth.ldap.ignoreCertErrors`              | if Certificate errors should be ignored                             | *see values.yaml*                            |
+| `remoteAuth.ldap.bindDn`                        | Distinguished Name to bind with                                     | `""`                                         |
+| `remoteAuth.ldap.bindPassword`                  | Password for bind DN                                                | `""`                                         |
+| `remoteAuth.ldap.userDnTemplate`                | see [AUTH_LDAP_USER_DN_TEMPLATE](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-user-dn-template) | *see values.yaml* |
+| `remoteAuth.ldap.userSearchBaseDn`              | see base_dn of [django_auth_ldap.config.LDAPSearch](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#django_auth_ldap.config.LDAPSearch) | *see values.yaml* |
+| `remoteAuth.ldap.userSearchAttr`                | User attribute name for user search                                 | `sAMAccountName`                             |
+| `remoteAuth.ldap.groupSearchBaseDn`             | base DN for group search                                            | *see values.yaml*                            |
+| `remoteAuth.ldap.groupSearchClass`              | [django-auth-ldap](https://django-auth-ldap.readthedocs.io) for group search | `group`                             |
+| `remoteAuth.ldap.groupType`                     | see [AUTH_LDAP_GROUP_TYPE](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-group-type) | `GroupOfNamesType` |
+| `remoteAuth.ldap.requireGroupDn`                | DN of a group that is required for login                            | `null`                                       |
+| `remoteAuth.ldap.findGroupPerms`                | see [AUTH_LDAP_FIND_GROUP_PERMS](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-find-group-perms) | true |
+| `remoteAuth.ldap.mirrorGroups`                  | see [AUTH_LDAP_MIRROR_GROUPS](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-mirror-groups) | `null` |
+| `remoteAuth.ldap.cacheTimeout`                  | see [AUTH_LDAP_MIRROR_GROUPS_EXCEPT](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-mirror-groups-except) | `null` |
+| `remoteAuth.ldap.isAdminDn`                     | required DN to be able to login in Admin-Backend, "is_staff"-Attribute of [AUTH_LDAP_USER_FLAGS_BY_GROUP](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-user-flags-by-group) | *see values.yaml* |
+| `remoteAuth.ldap.isSuperUserDn`                 | required DN to receive SuperUser privileges, "is_superuser"-Attribute of [AUTH_LDAP_USER_FLAGS_BY_GROUP](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-user-flags-by-group) | *see values.yaml* |
+| `remoteAuth.ldap.attrFirstName`                 | first name attribute of users, "first_name"-Attribute of [AUTH_LDAP_USER_ATTR_MAP](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-user-attr-map) | `givenName` |
+| `remoteAuth.ldap.attrLastName`                  | last name attribute of users, "last_name"-Attribute of [AUTH_LDAP_USER_ATTR_MAP](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-user-attr-map) | `sn` |
+| `remoteAuth.ldap.attrMail`                      | mail attribute of users, "email_name"-Attribute of [AUTH_LDAP_USER_ATTR_MAP](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-user-attr-map) | `mail` |
 | `releaseCheck.timeout`                          | How often NetBox queries GitHub for new releases, if enabled        | `86400`                                      |
 | `releaseCheck.url`                              | Release check URL (GitHub API URL; see `values.yaml`)               | `null` (disabled by default)                 |
 | `metricsEnabled`                                | Expose Prometheus metrics at the `/metrics` HTTP endpoint           | `false`                                      |
@@ -246,6 +266,20 @@ this, the `Secret` must contain the following keys:
 | `redis_password`       | Password for the external Redis tasks database         | If `redis.enabled` is `false` and `webhooksRedis.existingSecretName` is unset         |
 | `redis_cache_password` | Password for the external Redis cache database         | If `redis.enabled` is `false` and `cachingRedis.existingSecretName` is unset          |
 | `secret_key`           | Django session and password reset token encryption key | Yes, and should be 50+ random characters                                              |
+
+## Using LDAP Authentication
+
+For using LDAP for authentication, specify the ldap-docker image tag of netbox, e.g. "v2.10.3-ldap".
+
+Configuration is done via Helm release values. `remoteAuth` should be enabled and configured for LDAP, e.g.:
+
+```yaml
+remoteAuth:
+  enabled: true
+  backend: 'netbox.authentication.LDAPBackend'
+  ldap:
+    # see Configuration variables
+```
 
 ## License
 

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -178,3 +178,67 @@ data:
     SHORT_TIME_FORMAT: {{ .Values.shortTimeFormat | quote }}
     DATETIME_FORMAT: {{ .Values.dateTimeFormat | quote }}
     SHORT_DATETIME_FORMAT: {{ .Values.shortDateTimeFormat | quote }}
+
+  {{ if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" -}}
+  ldap_config.py: |
+    import yaml
+    import ldap
+    from django_auth_ldap.config import LDAPSearch
+    from importlib import import_module
+    def _load_yaml():
+      with open('/run/config/netbox/ldap.yaml', 'r') as f:
+        config = yaml.safe_load(f)
+      globals().update(config)
+    def _load_secret(name, key):
+      path = "/run/secrets/{name}/{key}".format(name=name, key=key)
+      with open(path, 'r') as f:
+        return f.read()
+    # Import and return the group type based on string name
+    def _import_group_type(group_type_name):
+        mod = import_module('django_auth_ldap.config')
+        try:
+            return getattr(mod, group_type_name)()
+        except:
+            return None
+    _load_yaml()
+    AUTH_LDAP_BIND_PASSWORD = _load_secret('netbox', 'ldap_bind_password')
+    # The following may be needed if you are binding to Active Directory.
+    AUTH_LDAP_CONNECTION_OPTIONS = {
+        ldap.OPT_REFERRALS: 0
+    }
+    AUTH_LDAP_USER_SEARCH = LDAPSearch(AUTH_LDAP_USER_SEARCH_BASEDN,
+                                      ldap.SCOPE_SUBTREE,
+                                      "(" + AUTH_LDAP_USER_SEARCH_ATTR + "=%(user)s)")
+    AUTH_LDAP_GROUP_SEARCH = LDAPSearch(AUTH_LDAP_GROUP_SEARCH_BASEDN, ldap.SCOPE_SUBTREE,
+                                  "(objectClass=" + AUTH_LDAP_GROUP_SEARCH_CLASS + ")")
+    AUTH_LDAP_GROUP_TYPE = _import_group_type(AUTH_LDAP_GROUP_TYPE)
+    # Define special user types using groups. Exercise great caution when assigning superuser status.
+    AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+        "is_active": AUTH_LDAP_REQUIRE_GROUP,
+        "is_staff": {{ .Values.remoteAuth.ldap.isAdminDn | quote }},
+        "is_superuser": {{ .Values.remoteAuth.ldap.isSuperUserDn | quote }}
+    }
+    # Populate the Django user from the LDAP directory.
+    AUTH_LDAP_USER_ATTR_MAP = {
+        "first_name": {{ .Values.remoteAuth.ldap.attrFirstName | quote }},
+        "last_name": {{ .Values.remoteAuth.ldap.attrLastName | quote }},
+        "email": {{ .Values.remoteAuth.ldap.attrMail | quote }}
+    }
+
+  ldap.yaml: |
+    AUTH_LDAP_SERVER_URI: {{ .Values.remoteAuth.ldap.serverUri | quote }}
+    AUTH_LDAP_BIND_DN: {{ .Values.remoteAuth.ldap.bindDn | quote }}
+    AUTH_LDAP_START_TLS: {{ toJson .Values.remoteAuth.ldap.startTls }}
+    LDAP_IGNORE_CERT_ERRORS: {{ toJson .Values.remoteAuth.ldap.ignoreCertErrors }}
+    AUTH_LDAP_USER_DN_TEMPLATE: {{ default nil .Values.remoteAuth.ldap.userDnTemplate }}
+    AUTH_LDAP_USER_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.userSearchBaseDn | quote }}
+    AUTH_LDAP_USER_SEARCH_ATTR: {{ .Values.remoteAuth.ldap.userSearchAttr | quote }}
+    AUTH_LDAP_GROUP_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.groupSearchBaseDn | quote }}
+    AUTH_LDAP_GROUP_SEARCH_CLASS: {{ .Values.remoteAuth.ldap.groupSearchClass | quote }}
+    AUTH_LDAP_GROUP_TYPE: {{ .Values.remoteAuth.ldap.groupType | quote }}
+    AUTH_LDAP_REQUIRE_GROUP: {{ .Values.remoteAuth.ldap.requireGroupDn | quote }}
+    AUTH_LDAP_FIND_GROUP_PERMS: {{ toJson .Values.remoteAuth.ldap.findGroupPerms }}
+    AUTH_LDAP_MIRROR_GROUPS: {{ toJson .Values.remoteAuth.ldap.mirrorGroups }}
+    AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson .Values.remoteAuth.ldap.mirrorGroupsExcept }}
+    AUTH_LDAP_CACHE_TIMEOUT: {{ int .Values.remoteAuth.ldap.cacheTimeout }}
+  {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -85,6 +85,12 @@ spec:
               mountPath: /etc/netbox/config/configuration.py
               subPath: configuration.py
               readOnly: true
+            {{ if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" -}}
+            - name: config
+              mountPath: /etc/netbox/config/ldap/ldap_config.py
+              subPath: ldap_config.py
+              readOnly: true
+            {{- end }}
             - name: config
               mountPath: /run/config/netbox
               readOnly: true

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -21,4 +21,7 @@ data:
   secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc }}
   superuser_password: {{ .Values.superuser.password | default (randAlphaNum 16) | b64enc }}
   superuser_api_token: {{ .Values.superuser.apiToken | default uuidv4 | b64enc }}
+  {{ if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" -}}
+  ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
+  {{ end -}}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -183,6 +183,31 @@ remoteAuth:
   autoCreateUser: true
   defaultGroups: []
   defaultPermissions: {}
+  # the following options are specific for backend "netbox.authentication.LDAPBackend"
+  # you can use an existing netbox secret with "ldap_bind_password" instead of "bindPassword"
+  # see https://django-auth-ldap.readthedocs.io
+  # ldap:
+  #   serverUri: 'ldap://domain.com'
+  #   startTls: true
+  #   ignoreCertErrors: false
+  #   bindDn: 'CN=Netbox,OU=EmbeddedDevices,OU=MyCompany,DC=domain,dc=com'
+  #   bindPassword: 'TopSecretPassword'
+  #   userDnTemplate: null
+  #   userSearchBaseDn: 'OU=Users,OU=MyCompany,DC=domain,dc=com'
+  #   userSearchAttr: 'sAMAccountName'
+  #   groupSearchBaseDn: 'OU=Groups,OU=MyCompany,DC=domain,dc=com'
+  #   groupSearchClass: 'group'
+  #   groupType: 'GroupOfNamesType'
+  #   requireGroupDn: ''
+  #   findGroupPerms: true
+  #   mirrorGroups: true
+  #   mirrorGroupsExcept: null
+  #   cacheTimeout: 3600
+  #   isAdminDn: 'CN=Network Configuration Operators,CN=Builtin,DC=domain,dc=com'
+  #   isSuperUserDn: 'CN=Domain Admins,CN=Users,DC=domain,dc=com'
+  #   attrFirstName: 'givenName'
+  #   attrLastName: 'sn'
+  #   attrMail: 'mail'
 
 releaseCheck:
   # This determines how often the GitHub API is called to check the latest


### PR DESCRIPTION
Hello together,

as we require LDAP for authentication, we've implemented existing solutions of [netbox-docker](https://github.com/netbox-community/netbox-docker).

A slightly modified version of [ldap_config.py](https://github.com/netbox-community/netbox-docker/blob/release/configuration/ldap/ldap_config.py) is added in `templates/configmap.yaml`.
Is called by default via [ldap_config.docker.py](https://github.com/netbox-community/netbox-docker/blob/release/docker/ldap_config.docker.py).

Additional mappings for Variables -> netbox global configuration variables are added as `ldap.py` in `templates/configmap.yaml`.
Are loaded via via [configuration.docker.py](https://github.com/netbox-community/netbox-docker/blob/release/docker/configuration.docker.py#L28).

As the underlying module is [django-auth-ldap](https://django-auth-ldap.readthedocs.io), README.md links to it for most configuration options.

Of course this is only usable with the ldap-version of netbox-docker, e.g. tags suffixed with "ldap": "v2.10.3-ldap"

We're using it successfully with 2.10.3 at the moment.