### PR TITLE
feat: support netbox 2.10.x

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v2.9.3
+appVersion: v2.10.4
 description: IP address management (IPAM) and data center infrastructure management (DCIM) tool
 icon: https://raw.githubusercontent.com/netbox-community/netbox/develop/docs/netbox_logo.png
 name: netbox

--- a/README.md
+++ b/README.md
@@ -192,11 +192,6 @@ The following table lists the configurable parameters for this chart and their d
 | `ingress.hosts`                                 | List of hosts and paths to map to the service (see `values.yaml`)   | `[{host:"chart-example.local",paths:["/"]}]` |
 | `ingress.tls`                                   | TLS settings for the `Ingress` resource                             | `[]`                                         |
 | `resources`                                     | Configure resource requests or limits for NetBox                    | `{}`                                         |
-| `nginx.image.repository`                        | NGINX container image repository for proxy and static file serving  | `nginx`                                      |
-| `nginx.image.tag`                               | NGINX container image tag                                           | `1.16.0-alpine`                              |
-| `nginx.image.pullPolicy`                        | NGINX container image pull policy                                   | `IfNotPresent`                               |
-| `nginx.resources`                               | Configure resource requests or limits for NGINX                     | `{}`                                         |
-| `nginx.securityContext`                         | Security context for NGINX sidecar containers                       | *see values.yaml*                            |
 | `autoscaling.enabled`                           | Whether to enable the HorizontalPodAutoscaler                       | `false`                                      |
 | `autoscaling.minReplicas`                       | Minimum number of replicas when autoscaling is enabled              | `1`                                          |
 | `autoscaling.maxReplicas`                       | Maximum number of replicas when autoscaling is enabled              | `100`                                        |

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -24,5 +24,5 @@ Get the application URL by running these commands:
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "netbox.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:8080
 {{- end }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -178,39 +178,3 @@ data:
     SHORT_TIME_FORMAT: {{ .Values.shortTimeFormat | quote }}
     DATETIME_FORMAT: {{ .Values.dateTimeFormat | quote }}
     SHORT_DATETIME_FORMAT: {{ .Values.shortDateTimeFormat | quote }}
-
-  nginx.conf: |
-    worker_processes 3;
-
-    error_log /dev/stderr info;
-
-    events {
-      worker_connections 1024;
-    }
-
-    http {
-      include              /etc/nginx/mime.types;
-      default_type         application/octet-stream;
-      sendfile             on;
-      tcp_nopush           on;
-      keepalive_timeout    65;
-      gzip                 on;
-      server_tokens        off;
-      client_max_body_size 10M;
-
-      server {
-        listen      8000;
-        access_log  off;
-
-        location /{{ .Values.basePath }}static/ {
-          alias /opt/netbox/netbox/static/;
-        }
-
-        location /{{ .Values.basePath }} {
-          proxy_pass http://localhost:8001;
-          proxy_set_header X-Forwarded-Host $http_host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-Proto $scheme;
-        }
-      }
-    }

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             {{- end }}
           ports:
             - name: netbox
-              containerPort: 8001
+              containerPort: 8080
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -80,13 +80,13 @@ spec:
             - name: media
               mountPath: /opt/netbox/netbox/media
               subPath: {{ .Values.persistence.subPath | default "" | quote }}
+            - name: nginx-unit
+              mountPath: /opt/unit
             {{- if .Values.reportsPersistence.enabled }}
             - name: reports
               mountPath: /opt/netbox/netbox/reports
               subPath: {{ .Values.reportsPersistence.subPath | default "" | quote }}
             {{- end }}
-            - name: static
-              mountPath: /opt/netbox/netbox/static
             {{- if or .Values.postgresql.enabled .Values.externalDatabase.existingSecretName }}
             - name: db-secret
               mountPath: /run/secrets/database
@@ -123,36 +123,6 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
-        - name: nginx
-          securityContext:
-            {{- toYaml .Values.nginx.securityContext | nindent 12 }}
-          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
-          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
-          command: [nginx, -g, 'daemon off;']
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /{{ .Values.basePath }}
-              port: http
-          volumeMounts:
-            - name: config
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
-              readOnly: true
-            - name: static
-              mountPath: /opt/netbox/netbox/static
-              readOnly: true
-            - name: nginx-cache
-              mountPath: /var/cache/nginx
-            - name: nginx-run
-              mountPath: /run
-          {{- if .Values.nginx.resources }}
-          resources:
-            {{- toYaml .Values.nginx.resources | nindent 12 }}
-          {{- end }}
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -174,25 +144,20 @@ spec:
         - name: netbox-tmp
           emptyDir:
             medium: Memory
-        - name: nginx-cache
-          emptyDir: {}
-        - name: nginx-run
-          emptyDir:
-            medium: Memory
         - name: media
-        {{- if .Values.persistence.enabled }}
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "netbox.fullname" .)) }}
-        {{- else }}
+          {{- else }}
           emptyDir: {}
-        {{- end }}
+          {{- end }}
+        - name: nginx-unit
+          emptyDir: {}
         {{- if .Values.reportsPersistence.enabled }}
         - name: reports
           persistentVolumeClaim:
             claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "netbox.fullname" .)) }}
         {{- end }}
-        - name: static
-          emptyDir: {}
         {{- if or .Values.postgresql.enabled .Values.externalDatabase.existingSecretName }}
         - name: db-secret
           secret:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: netbox
           {{- else }}
           - {{ . | toYaml | indent 12 | trim }}
           {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -12,9 +12,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: netbox
       protocol: TCP
-      name: http
+      name: netbox
   selector:
     {{- include "netbox.selectorLabels" . | nindent 4 }}
   {{- with .Values.service.loadBalancerSourceRanges }}

--- a/values.yaml
+++ b/values.yaml
@@ -410,23 +410,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-nginx:
-  image:
-    repository: nginx
-    tag: 1.18.0-alpine
-    pullPolicy: IfNotPresent
-
-  resources: {}
-
-  securityContext:
-    capabilities:
-      drop:
-        - ALL
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsUser: 101
-    runAsGroup: 1000  # Keep the same as securityContext.runAsGroup
-
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
Netbox 2.10.x (netbox-docker > 1.0) drops the use of an nginx container for static content in favor of a single container running nginx unit. To support Netbox 2.10.x:

1. Remove nginx container from deployment.
2. Add `/opt/unit` as directory-only volume, as nginx unit will attempt to write to this directory (and the podSecurityPolicy prohibits this)
3. Update appVersion to v2.10.4, as this change is not backwards compatible with Netbox 2.9.x
