### PR TITLE
Add pod labels support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The following table lists the configurable parameters for this chart and their d
 | `reportsPersistence.accessMode`                 | Access mode for the volume                                          | `ReadWriteOnce`                              |
 | `reportsPersistence.size`                       | Size of persistent volume to request                                | `1Gi`                                        |
 | `podAnnotations`                                | Additional annotations for NetBox pods                              | `{}`                                         |
+| `podLabels`                                     | Additional labels for NetBox pods                                   | `{}`                                         |
 | `podSecurityContext`                            | Security context for NetBox pods                                    | *see `values.yaml`*                          |
 | `securityContext`                               | Security context for NetBox containers                              | *see `values.yaml`*                          |
 | `service.type`                                  | Type of `Service` resource to create                                | `ClusterIP`                                  |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       labels:
         {{- include "netbox.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: netbox
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -31,6 +31,9 @@ spec:
       labels:
         {{- include "netbox.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: worker
+        {{- with .Values.worker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -386,6 +386,8 @@ reportsPersistence:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext:
   # fsGroup: 1000
   runAsNonRoot: true
@@ -521,6 +523,8 @@ worker:
   replicaCount: 1
 
   podAnnotations: {}
+
+  podLabels: {}
 
   podSecurityContext:
     # fsGroup: 1000


### PR DESCRIPTION
For our use case it is to support Azure aad-pod-identity as it uses a pod label to do the binding:
https://azure.github.io/aad-pod-identity/docs/demo/standard_walkthrough/#6-deployment-and-validation