### PR TITLE
Updated ingress apiVersion from v1beta1 to v1

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "netbox.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Ingress apiVersion v1beta1 is deprecated since k8s 1.19+ and will be unusable in k8s 1.22+. Its therefor a good idea to set the new and proper apiVersion to not break this awesome chart.