### PR TITLE
feat(values): add commonLabels and commonAnnotations

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -65,6 +65,9 @@ helm.sh/chart: {{ include "netbox.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "netbox.fullname" . }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "netbox.labels" . | indent 4 }}
 data:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "netbox.fullname" . }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "netbox.labels" . | nindent 4 }}
 spec:

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -3,6 +3,10 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "netbox.fullname" . }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "netbox.labels" . | nindent 4 }}
 spec:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -11,9 +11,14 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "netbox.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if or .Values.commonAnnotations .Values.ingress.annotations }}
   annotations:
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   {{- if .Values.ingress.tls }}

--- a/templates/pvc-media.yaml
+++ b/templates/pvc-media.yaml
@@ -3,6 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "netbox.fullname" . }}-media
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "netbox.labels" . | indent 4 }}
 spec:

--- a/templates/pvc-reports.yaml
+++ b/templates/pvc-reports.yaml
@@ -3,6 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "netbox.fullname" . }}-reports
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "netbox.labels" . | indent 4 }}
 spec:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "netbox.fullname" . }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "netbox.labels" . | indent 4 }}
 type: Opaque

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,9 +4,14 @@ metadata:
   name: {{ include "netbox.fullname" . }}
   labels:
     {{- include "netbox.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
+  {{- if or .Values.commonAnnotations .Values.service.annotations }}
   annotations:
+  {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -5,8 +5,13 @@ metadata:
   name: {{ include "netbox.serviceAccountName" . }}
   labels:
     {{- include "netbox.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
   annotations:
+  {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -4,6 +4,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "netbox.fullname" . }}-worker
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "netbox.labels" . | nindent 4 }}
 spec:

--- a/templates/worker-hpa.yaml
+++ b/templates/worker-hpa.yaml
@@ -3,8 +3,15 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "netbox.fullname" . }}-worker
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "netbox.worker.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/values.yaml
+++ b/values.yaml
@@ -389,6 +389,10 @@ reportsPersistence:
   ## Persistant storage size request
   size: 1Gi
 
+commonLabels: {}
+
+commonAnnotations: {}
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
# Description

This PR adds the ability to set custom labels and custom annotations on any resource generated by the chart (not subchart !) with the dictionnaries `commonLabels` and `commonAnnotations`, empty by default.

Partially fixes #60 (pod labels are not covered by my PR as long as it is not a direct resource generated by the chart and covered by https://github.com/bootc/netbox-chart/commit/198e74703345902cda043f850ca273ec47811b40)

## Type of change

* For the labels, I used the helper.tpl `netbox.labels` which is already in all resources (except worker-hpa). I added this at the end of the template function
```
{{- with .Values.commonLabels }}
{{ toYaml . }}
{{- end }}
```

For worker-hpa I added this in labels :

```
{{- with .Values.commonLabels }}
      {{- toYaml . | nindent 4 }}
    {{- end }}
```

* For the annotations, I added this in annotations in all resources :

```
{{- with .Values.commonAnnotations }}
  annotations:
    {{- toYaml . | nindent 4 }}
  {{- end }}
``` 

If the resources already had annotations, I added this (for service, serviceAccount and ingress) in annotations :

```
{{- if or .Values.commonAnnotations .Values.service.annotations }}
  annotations:
  {{- with .Values.service.annotations }}
    {{- toYaml . | nindent 4 }}
  {{- end }}
  {{- with .Values.commonAnnotations }}
    {{- toYaml . | nindent 4 }}
  {{- end }}
  {{- end }}
```

# How Has This Been Tested?

**Test Configuration** :
Helm 3.7.1 `version.BuildInfo{Version:"v3.7.1", GitCommit:"1d11fcb5d3f3bf00dbe6fe31b8412839a96b3dc4", GitTreeState:"clean", GoVersion:"go1.16.9"}`

- [x] No diff between my changes with default values and without my changes, so no breaking changes
- [x] Tried with service.annotations empty commonAnnotations and inversely
- [x] Tried with service.annotations and commonAnnotations and commonLabels
- [x] `helm lint . --strict` returns no errors
- [x] With `yamllint 1.20.0`, `yamllint --strict .` returns nothing

# Anything else ?

Why isn't there a Chart.lock for subcharts ? It would ensure we are all working with same subcharts as per the doc says : https://helm.sh/docs/helm/helm_dependency_build/. I can add one if you want.
