### PR TITLE
Fix indentation for imagePullSecrets in CronJob template

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -40,7 +40,7 @@ spec:
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           serviceAccountName: {{ include "netbox.serviceAccountName" . }}
           securityContext:


### PR DESCRIPTION
Fix for cronjob.yaml indentation problem when imagePullSecrets is specified.