### PR TITLE
Fix/ldap yaml quoting

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -214,8 +214,8 @@ data:
     # Define special user types using groups. Exercise great caution when assigning superuser status.
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {
         "is_active": AUTH_LDAP_REQUIRE_GROUP,
-        "is_staff": {{ .Values.remoteAuth.ldap.isAdminDn | quote }},
-        "is_superuser": {{ .Values.remoteAuth.ldap.isSuperUserDn | quote }}
+        "is_staff": {{ .Values.remoteAuth.ldap.isAdminDn | squote }},
+        "is_superuser": {{ .Values.remoteAuth.ldap.isSuperUserDn | squote }}
     }
     # Populate the Django user from the LDAP directory.
     AUTH_LDAP_USER_ATTR_MAP = {

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -225,17 +225,17 @@ data:
     }
 
   ldap.yaml: |
-    AUTH_LDAP_SERVER_URI: {{ .Values.remoteAuth.ldap.serverUri | quote }}
-    AUTH_LDAP_BIND_DN: {{ .Values.remoteAuth.ldap.bindDn | quote }}
+    AUTH_LDAP_SERVER_URI: {{ .Values.remoteAuth.ldap.serverUri | squote }}
+    AUTH_LDAP_BIND_DN: {{ .Values.remoteAuth.ldap.bindDn | squote }}
     AUTH_LDAP_START_TLS: {{ toJson .Values.remoteAuth.ldap.startTls }}
     LDAP_IGNORE_CERT_ERRORS: {{ toJson .Values.remoteAuth.ldap.ignoreCertErrors }}
     AUTH_LDAP_USER_DN_TEMPLATE: {{ default nil .Values.remoteAuth.ldap.userDnTemplate }}
-    AUTH_LDAP_USER_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.userSearchBaseDn | quote }}
-    AUTH_LDAP_USER_SEARCH_ATTR: {{ .Values.remoteAuth.ldap.userSearchAttr | quote }}
-    AUTH_LDAP_GROUP_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.groupSearchBaseDn | quote }}
-    AUTH_LDAP_GROUP_SEARCH_CLASS: {{ .Values.remoteAuth.ldap.groupSearchClass | quote }}
-    AUTH_LDAP_GROUP_TYPE: {{ .Values.remoteAuth.ldap.groupType | quote }}
-    AUTH_LDAP_REQUIRE_GROUP: {{ .Values.remoteAuth.ldap.requireGroupDn | quote }}
+    AUTH_LDAP_USER_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.userSearchBaseDn | squote }}
+    AUTH_LDAP_USER_SEARCH_ATTR: {{ .Values.remoteAuth.ldap.userSearchAttr | squote }}
+    AUTH_LDAP_GROUP_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.groupSearchBaseDn | squote }}
+    AUTH_LDAP_GROUP_SEARCH_CLASS: {{ .Values.remoteAuth.ldap.groupSearchClass | squote }}
+    AUTH_LDAP_GROUP_TYPE: {{ .Values.remoteAuth.ldap.groupType | squote }}
+    AUTH_LDAP_REQUIRE_GROUP: {{ .Values.remoteAuth.ldap.requireGroupDn | squote }}
     AUTH_LDAP_FIND_GROUP_PERMS: {{ toJson .Values.remoteAuth.ldap.findGroupPerms }}
     AUTH_LDAP_MIRROR_GROUPS: {{ toJson .Values.remoteAuth.ldap.mirrorGroups }}
     AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson .Values.remoteAuth.ldap.mirrorGroupsExcept }}


### PR DESCRIPTION
This PR aims to fix the case, when LDAP DNs have space in their name, such as: `CN=blah,OU=Teams,OU=Staff Groups,DC=redacted,DC=redacted,DC=redacted`. 

Previously these values were rendered with double quotes in the `ldap.yaml` file and the values were interpreted as two separate ones for example:

```
'GROUP_SEARCH_BASEDN': 'OU=Teams,OU=Staff'
                        'Groups,DC=redacted,DC=redacted,DC=redacted',
```