### PR TITLE
Make readiness probe configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ The following table lists the configurable parameters for this chart and their d
 | `ingress.hosts`                                 | List of hosts and paths to map to the service (see `values.yaml`)   | `[{host:"chart-example.local",paths:["/"]}]` |
 | `ingress.tls`                                   | TLS settings for the `Ingress` resource                             | `[]`                                         |
 | `resources`                                     | Configure resource requests or limits for NetBox                    | `{}`                                         |
+| `readinessProbe.enabled`                        | Enable Kubernetes readinessProbe, see [readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) | *see `values.yaml`* |
+| `readinessProbe.initialDelaySeconds`            | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `readinessProbe.timeoutSeconds`                 | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `readinessProbe.periodSeconds`                  | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `readinessProbe.successThreshold`               | Number of seconds                                                   |  *see `values.yaml`*                         |
 | `init.image.repository`                         | Init container image repository                                     | `busybox`                                    |
 | `init.image.tag`                                | Init container image tag                                            | `1.32.1`                                     |
 | `init.image.pullPolicy`                         | Init container image pull policy                                    | `IfNotPresent`                               |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -82,15 +82,21 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /{{ .Values.basePath }}login/
               port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
               {{- if (not (eq (index .Values.allowedHosts 0) "*")) }}
               httpHeaders:
                 - name: Host
                   value: {{ (index .Values.allowedHosts 0) | quote }}
               {{- end }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/netbox/config/configuration.py

--- a/values.yaml
+++ b/values.yaml
@@ -497,6 +497,13 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  periodSeconds: 10
+  successThreshold: 1
+
 init:
   image:
     repository: busybox


### PR DESCRIPTION
This PR aims to allow for more flexibility in the readiness probe configuration. This was causing events in our NetBox set up and allowing for a longer timeout resolved this.