### PR TITLE
update chart to deploy v3.1.9 by default

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: netbox
-version: 4.0.1
-appVersion: v3.0.11
+version: 4.0.2
+appVersion: v3.1.9
 description: IP address management (IPAM) and data center infrastructure management (DCIM) tool
 home: https://github.com/bootc/netbox-chart
 icon: https://raw.githubusercontent.com/netbox-community/netbox/develop/docs/netbox_logo.png


### PR DESCRIPTION
update chart to deploy v3.1.9 by default addessing https://github.com/bootc/netbox-chart/issues/83