### PR TITLE
Use proper indentation for nodeSelector, affinity, tolerations

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -158,15 +158,15 @@ spec:
             {{- end }}
           {{- with .Values.housekeeping.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.housekeeping.affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.housekeeping.tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           restartPolicy: {{ .Values.housekeeping.restartPolicy }}
 {{- end -}}


### PR DESCRIPTION
Without this change, the CronJob can not be configured with custom affinity, nodeSelector, or tolerations.