### PR TITLE
Add serviceMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,11 @@ The following table lists the configurable parameters for this chart and their d
 | `maxPageSize`                                   | Maximum number of objects that can be returned by a single API call | `1000`                                       |
 | `storageBackend`                                | Django-storages backend class name                                  | `null`                                       |
 | `storageConfig`                                 | Django-storages backend configuration                               | `{}`                                         |
-| `metricsEnabled`                                | Expose Prometheus metrics at the `/metrics` HTTP endpoint           | `false`                                      |
+| `metrics.enabled`                               | Expose Prometheus metrics at the `/metrics` HTTP endpoint           | `false`                                      |
+| `metrics.scrapeInterval`                        | Prometheus scrape interval                                          | `30s`                                        |
+| `metrics.scrapeTimeout`                         | Prometheus scrape timeout                                           | `10s`                                        |
+| `metrics.serviceMonitor.enabled`                | Enable Prometheus Operator handled ServiceMonitor                   | `false`                                      |
+| `metrics.serviceMonitor.additionalLabels`       | Additional labels for Prometheus Operator handled ServiceMonitor    | `{}`                                         |
 | `napalm.username`                               | Username used by the NAPALM library to access network devices       | `""`                                         |
 | `napalm.password`                               | Password used by the NAPALM library (see also `existingSecret`)     | `""`                                         |
 | `napalm.timeout`                                | Timeout for NAPALM to connect to a device (in seconds)              | `30`                                         |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -108,7 +108,7 @@ data:
     MEDIA_ROOT: /opt/netbox/netbox/media
     STORAGE_BACKEND: {{ .Values.storageBackend | quote }}
     STORAGE_CONFIG:  {{ toJson .Values.storageConfig }}
-    METRICS_ENABLED: {{ toJson .Values.metricsEnabled }}
+    METRICS_ENABLED: {{ toJson .Values.metrics.enabled }}
     NAPALM_USERNAME: {{ .Values.napalm.username | quote }}
     NAPALM_TIMEOUT: {{ int .Values.napalm.timeout }}
     NAPALM_ARGS: {{ toJson .Values.napalm.args }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "netbox.fullname" . }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "netbox.labels" . | nindent 4 }}
+  {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: netbox
+  endpoints:
+  - port: http
+    interval: {{ .Values.metrics.scrapeInterval }}
+    scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -155,7 +155,15 @@ storageConfig: {}
   # AWS_S3_REGION_NAME: 'eu-west-1'
 
 # Expose Prometheus monitoring metrics at the HTTP endpoint '/metrics'
-metricsEnabled: false
+metrics:
+  enabled: false
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+
+# Set up metrics scraping with Prometheus Operator
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
 
 napalm:
   # Credentials that NetBox will use to access live devices.


### PR DESCRIPTION
Add `ServiceMonitor` object to easily set up metrics scraping with Prometheus Operator.

As you can see, the change is backward incompatible as `metricsEnabled` has been renamed to `metrics.enabled`