### PR TITLE
Added libpq option target_session_attrs for cluster support

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -82,6 +82,7 @@ data:
       {{- end }}
       OPTIONS:
         sslmode: {{ .Values.externalDatabase.sslMode | quote }}
+        target_session_attrs: 'read-write'
       CONN_MAX_AGE: {{ .Values.externalDatabase.connMaxAge | int }}
 
     ADMINS: {{ toJson .Values.admins }}


### PR DESCRIPTION
Since PostgreSQL 10 the C library libpq, that is used by psycopg, that itself is used in Django and therefore NetBox, supports specifying multiple PostgreSQL hosts and a kind of selector.

See these links:
* https://www.postgresql.org/docs/14/libpq-connect.html#LIBPQ-CONNSTRING
* https://www.postgresql.org/docs/14/libpq-connect.html#LIBPQ-CONNECT-TARGET-SESSION-ATTRS

Basically one is able to specify multiple hosts and what a session to a host should support.
libpq will then try each host and use first matching one.
In the case of an aborted connection or if a failover happens, the application will still get an error, but is able to retry and a new host will be searched for automatically.

The added option in this PR is compatible to single hosts as well.
And it makes sense to set as default, because NetBox only really supports ReadWrite-connections.

Without this session attr NetBox will allow a readonly database connection.
When NetBox is using a readonly session, it will throw exceptions for each write action (e.g. user login) and reconnect to the database.
So this would be a behaviour change in that a readonly session is not allowed anymore. Currently NetBox would somewhat work for users being already logged in and only issuing readonly requests. But this I would not call a feature of NetBox.

What this PR will & can not fix, is that NetBox itself does only reconnect to the database, when an exception is thrown.
As `netbox-docker` uses nginx-unit with multiple app processes, hypothetically all processes (e.g. 4 pods with 4 processes = 16 processes) will throw an exception individually before all db connections are refreshed.
I've omitted factors like max db connection age & load-scaling of application processes in this simple example, but you get the idea.