### PR TITLE
nindent in CronJob is incorrect

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -38,10 +38,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:
-          {{- with .Values.housekeeping.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 8 }}
@@ -162,11 +158,15 @@ spec:
             {{- end }}
           {{- with .Values.housekeeping.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.housekeeping.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.housekeeping.tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           restartPolicy: {{ .Values.housekeeping.restartPolicy }}
 {{- end -}}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -38,6 +38,10 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:
+          {{- with .Values.housekeeping.affinity }}
+          affinity:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 8 }}
@@ -158,10 +162,6 @@ spec:
             {{- end }}
           {{- with .Values.housekeeping.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.housekeeping.affinity }}
-          affinity:
             {{- toYaml . | nindent 8 }}
           {{- end }}
           {{- with .Values.housekeeping.tolerations }}


### PR DESCRIPTION
In the CronJob file the `nindent` is too small, if 8 are correct it would be 12.