### PR TITLE
Fix allowedHosts which is broken since 4.1.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 4.1.0
+version: 4.1.1
 appVersion: v3.2.6
 description: IP address management (IPAM) and data center infrastructure management (DCIM) tool
 home: https://github.com/bootc/netbox-chart

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -91,15 +91,15 @@ spec:
             httpGet:
               path: /{{ .Values.basePath }}login/
               port: http
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
               {{- if (not (eq (index .Values.allowedHosts 0) "*")) }}
               httpHeaders:
                 - name: Host
                   value: {{ (index .Values.allowedHosts 0) | quote }}
               {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           {{- end }}
           volumeMounts:
             - name: config


### PR DESCRIPTION
https://github.com/bootc/netbox-chart/pull/81 breaks the helm chart when
a value for `.Values.allowedHosts` is used. `httpHeaders` is a subkey of
`httpGet` and the newly added values are siblings of `httpGet`. Putting
those new values between `httpGet` and `httpHeaders` breaks the position
and indentation of `httpHeaders`.

As a solution this commit moves the new values after `httpHeaders`.