### PR TITLE
Create optional ServiceMonitor for Netbox

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 4.1.1
+version: 4.2.0
 appVersion: v3.2.8
 description: IP address management (IPAM) and data center infrastructure management (DCIM) tool
 home: https://github.com/bootc/netbox-chart

--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ The following table lists the configurable parameters for this chart and their d
 | `dateFormat`                                    | Django date format for long-form date strings                       | `"N j, Y"`                                   |
 | `shortDateFormat`                               | Django date format for short-form date strings                      | `"Y-m-d"`                                    |
 | `timeFormat`                                    | Django date format for long-form time strings                       | `"g:i a"`                                    |
+| `servicemonitor.enabled`                        | Whether to enable a [ServiceMonitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) for Netbox | `false`                                      |
+| `servicemonitor.additionalLabels`               | Additonal labels to apply to the ServiceMonitor                     | `{}`                                         |
+| `servicemonitor.interval`                       | Interval to scrape metrics.                                         | `1m`                                         |
+| `servicemonitor.scrapeTimeout`                  | Timeout duration for scraping metrics                               | `10s`                                        |
 | `shortTimeFormat`                               | Django date format for short-form time strings                      | `"H:i:s"`                                    |
 | `dateTimeFormat`                                | Django date format for long-form date and time strings              | `"N j, Y g:i a"`                             |
 | `shortDateTimeFormat`                           | Django date format for short-form date and time strongs             | `"Y-m-d H:i"`                                |

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.metricsEnabled .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "netbox.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "netbox.labels" . | nindent 4 }}
+  {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "netbox.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout  }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -659,6 +659,11 @@ extraInitContainers: []
 #    image: busybox
 #    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
 
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+  interval: 1m
+  scrapeTimeout: 10s
 
 # Configuration of Cron settings
 housekeeping:


### PR DESCRIPTION
The Prometheus-Operator is a popular choice for collecting metrics, and many other projects (such as External-DNS [1]) have a pre-configured ServiceMonitor resource ready to be enabled; this does the same for Netbox.

The template is very heavily inspired by the External-DNS one.

1: https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/templates/servicemonitor.yaml