### PR TITLE
redis.clusterDomain

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -399,7 +399,8 @@ redis:
   # To use an external Redis instance, set this to false and configure the
   # settings under *both* tasksRedis *and* cachingRedis
   enabled: true
-
+  clusterDomain: cluster.local
+  
 tasksRedis:
   database: 0
   ssl: false


### PR DESCRIPTION
If your cluster domain differs from "cluster.local" - redis replicas will fail to connect to master