### PR TITLE
Fix: Deployment Failure when using hostAliases

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -226,5 +226,5 @@ spec:
       {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
-        {{- toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -172,6 +172,6 @@ spec:
       {{- end }}
       {{- with .Values.worker.hostAliases }}
       hostAliases:
-        {{- toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix: Deployment Failure when using hostAliases closes #128 and use `nindent` instead.