### PR TITLE
Added support for external Redis CA

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 4.1.1
+version: 4.1.2
 appVersion: v3.2.8
 description: IP address management (IPAM) and data center infrastructure management (DCIM) tool
 home: https://github.com/bootc/netbox-chart

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -174,6 +174,7 @@ data:
         DATABASE: {{ int .Values.tasksRedis.database }}
         SSL: {{ toJson .Values.tasksRedis.ssl }}
         INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.tasksRedis.insecureSkipTlsVerify }}
+        CA_CERT_PATH: {{ toJson .Values.tasksRedis.caCertPath}}
       caching:
         {{- if .Values.redis.enabled }}
         HOST: {{ printf "%s-master" (include "netbox.redis.fullname" .) | quote }}
@@ -189,6 +190,7 @@ data:
         DATABASE: {{ int .Values.cachingRedis.database }}
         SSL: {{ toJson .Values.cachingRedis.ssl }}
         INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.cachingRedis.insecureSkipTlsVerify }}
+        CA_CERT_PATH: {{ toJson .Values.cachingRedis.caCertPath}}
 
     REPORTS_ROOT: /opt/netbox/netbox/reports
     RQ_DEFAULT_TIMEOUT: {{ .Values.rqDefaultTimeout | int }}

--- a/values.yaml
+++ b/values.yaml
@@ -404,6 +404,7 @@ tasksRedis:
   database: 0
   ssl: false
   insecureSkipTlsVerify: false
+  caCertPath: ""
 
   # Used only when redis.enabled is false. host and port are not used if
   # sentinels are given.


### PR DESCRIPTION
Netbox V3.4.3 introduced the option to specify a path for a custom Redis CA cert path.
This was not supported in the current chart, this should be supported with my edits.

If anything looks wrong or i have overlooked something be sure to tell me (: 