### PR TITLE
Add ability to set target_session_attrs value for externalDatabase

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -82,7 +82,11 @@ data:
       {{- end }}
       OPTIONS:
         sslmode: {{ .Values.externalDatabase.sslMode | quote }}
+        {{ if .Values.postgresql.enabled -}}
         target_session_attrs: 'read-write'
+        {{- else -}}
+        target_session_attrs: {{ .Values.externalDatabase.targetSessionAttrs | quote }}
+        {{- end }}
       CONN_MAX_AGE: {{ .Values.externalDatabase.connMaxAge | int }}
       DISABLE_SERVER_SIDE_CURSORS: {{ toJson .Values.externalDatabase.disableServerSideCursors }}
 

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -82,11 +82,7 @@ data:
       {{- end }}
       OPTIONS:
         sslmode: {{ .Values.externalDatabase.sslMode | quote }}
-        {{ if .Values.postgresql.enabled -}}
-        target_session_attrs: 'read-write'
-        {{- else -}}
-        target_session_attrs: {{ .Values.externalDatabase.targetSessionAttrs | quote }}
-        {{- end }}
+        target_session_attrs: {{ .Values.externalDatabase.targetSessionAttrs | default "read-write" | quote }}
       CONN_MAX_AGE: {{ .Values.externalDatabase.connMaxAge | int }}
       DISABLE_SERVER_SIDE_CURSORS: {{ toJson .Values.externalDatabase.disableServerSideCursors }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -388,6 +388,7 @@ externalDatabase:
   password: ""
   existingSecretName: ""
   existingSecretKey: postgresql-password
+  targetSessionAttrs: 'read-write'
 
   # The following settings also apply when using the bundled PostgreSQL chart:
   sslMode: prefer

--- a/values.yaml
+++ b/values.yaml
@@ -388,7 +388,6 @@ externalDatabase:
   password: ""
   existingSecretName: ""
   existingSecretKey: postgresql-password
-  targetSessionAttrs: 'read-write'
 
   # The following settings also apply when using the bundled PostgreSQL chart:
   sslMode: prefer


### PR DESCRIPTION
We experienced connection errors between netbox and postgresql pgpool service (`postgresql-ha` bitnami helm chart). The following error occurred in UI:
![error 2023-02-01 11-36-37](https://user-images.githubusercontent.com/40362174/216968851-910d0997-aa5f-4a46-9468-5d0cb91b962f.png)
The following error message was in the log:
```
Internal Server Error: /virtualization/interfaces/
Traceback (most recent call last):
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/sessions/backends/base.py", line 187, in _get_session
    return self._session_cache
AttributeError: 'SessionStore' object has no attribute '_session_cache'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/base/base.py", line 244, in ensure_connection
    self.connect()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/base/base.py", line 225, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django_prometheus/db/common.py", line 45, in get_new_connection
    return super().get_new_connection(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/postgresql/base.py", line 203, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/opt/netbox/venv/lib/python3.9/site-packages/psycopg2/__init__.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: could not make a writable connection to server "netbox-postgresql-postgresql-ha-pgpool:5432"


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/opt/netbox/netbox/netbox/middleware.py", line 27, in __call__
    if settings.LOGIN_REQUIRED and not request.user.is_authenticated:
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/functional.py", line 258, in inner
    self._setup()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/functional.py", line 398, in _setup
    self._wrapped = self._setupfunc()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/auth/middleware.py", line 25, in <lambda>
    request.user = SimpleLazyObject(lambda: get_user(request))
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/auth/middleware.py", line 11, in get_user
    request._cached_user = auth.get_user(request)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/auth/__init__.py", line 191, in get_user
    user_id = _get_user_session_key(request)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/auth/__init__.py", line 60, in _get_user_session_key
    return get_user_model()._meta.pk.to_python(request.session[SESSION_KEY])
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/sessions/backends/base.py", line 53, in __getitem__
    return self._session[key]
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/sessions/backends/base.py", line 192, in _get_session
    self._session_cache = self.load()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/sessions/backends/db.py", line 42, in load
    s = self._get_session_from_db()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/contrib/sessions/backends/db.py", line 32, in _get_session_from_db
    return self.model.objects.get(
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/models/query.py", line 492, in get
    num = len(clone)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/models/query.py", line 302, in __len__
    self._fetch_all()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/models/query.py", line 1507, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/models/query.py", line 57, in __iter__
    results = compiler.execute_sql(
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 1359, in execute_sql
    cursor = self.connection.cursor()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/base/base.py", line 284, in cursor
    return self._cursor()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/base/base.py", line 260, in _cursor
    self.ensure_connection()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/base/base.py", line 244, in ensure_connection
    self.connect()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/base/base.py", line 244, in ensure_connection
    self.connect()
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/base/base.py", line 225, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django_prometheus/db/common.py", line 45, in get_new_connection
    return super().get_new_connection(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.9/site-packages/django/db/backends/postgresql/base.py", line 203, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/opt/netbox/venv/lib/python3.9/site-packages/psycopg2/__init__.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
django.db.utils.OperationalError: could not make a writable connection to server "netbox-postgresql-postgresql-ha-pgpool:5432"
```
The problem appeared after postresql-ha helm chart upgrade to 10.0.9 version, netbox-chart wasn't touched (version 4.1.1).
After some investigation, we tried to set `target_session_attrs` to `any` manually and it fixed our problem. Therefore this PR aims to allow users to set the option via helm values.