### PR TITLE
Add 'serviceAccount.imagePullSecrets' option.

### DIFF
--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -14,4 +14,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -464,6 +464,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Existing secret name to use for container registry authentication
+  imagePullSecrets: []
 
 ## Storage configuration for media
 persistence:


### PR DESCRIPTION
Provides the option to set the `imagePullSecrets` on the ServiceAccount instead of the deployment.