### PR TITLE
hpa chg. because Kubernetes 1.25 only supports v2

### DIFF
--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "netbox.fullname" . }}

--- a/templates/worker-hpa.yaml
+++ b/templates/worker-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.worker.enabled .Values.worker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "netbox.fullname" . }}-worker


### PR DESCRIPTION
Hi,

we upgraded our Kubernetes to version 1.25. The tag v2beta1 is not longer supported.