### PR TITLE
adding support for create groups via remote authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.backend`                            | Remote authentication backend class                                 | `netbox.authentication.RemoteUserBackend`    |
 | `remoteAuth.header`                             | The name of the HTTP header which conveys the username              | `HTTP_REMOTE_USER`                           |
 | `remoteAuth.autoCreateUser`                     | Enables the automatic creation of new users                         | `true`                                       |
+| `remoteAuth.autoCreateGroups`                   | Enables the automatic creation of newgroups                         | `false`                                      |
 | `remoteAuth.defaultGroups`                      | A list of groups to assign to newly created users                   | `[]`                                         |
 | `remoteAuth.defaultPermissions`                 | A list of permissions to assign newly created users                 | `{}`                                         |
 | `remoteAuth.groupSyncEnabled`                   | Sync remote user groups from an HTTP header set by a reverse proxy  | `false`                                      |

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.backend`                            | Remote authentication backend class                                 | `netbox.authentication.RemoteUserBackend`    |
 | `remoteAuth.header`                             | The name of the HTTP header which conveys the username              | `HTTP_REMOTE_USER`                           |
 | `remoteAuth.autoCreateUser`                     | Enables the automatic creation of new users                         | `true`                                       |
-| `remoteAuth.autoCreateGroups`                   | Enables the automatic creation of newgroups                         | `false`                                      |
+| `remoteAuth.autoCreateGroups`                   | Enables the automatic creation of new groups                        | `false`                                      |
 | `remoteAuth.defaultGroups`                      | A list of groups to assign to newly created users                   | `[]`                                         |
 | `remoteAuth.defaultPermissions`                 | A list of permissions to assign newly created users                 | `{}`                                         |
 | `remoteAuth.groupSyncEnabled`                   | Sync remote user groups from an HTTP header set by a reverse proxy  | `false`                                      |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -150,6 +150,7 @@ data:
     REMOTE_AUTH_BACKEND: {{ .Values.remoteAuth.backend | quote }}
     REMOTE_AUTH_HEADER: {{ .Values.remoteAuth.header | quote }}
     REMOTE_AUTH_AUTO_CREATE_USER: {{ toJson .Values.remoteAuth.autoCreateUser }}
+    REMOTE_AUTH_AUTO_CREATE_GROUPS: {{ toJson .Values.remoteAuth.autoCreateGroups }}
     REMOTE_AUTH_DEFAULT_GROUPS: {{ toJson .Values.remoteAuth.defaultGroups }}
     REMOTE_AUTH_DEFAULT_PERMISSIONS: {{ toJson .Values.remoteAuth.defaultPermissions }}
     REMOTE_AUTH_GROUP_SYNC_ENABLED: {{ toJson .Values.remoteAuth.groupSyncEnabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -274,6 +274,7 @@ remoteAuth:
   backend: netbox.authentication.RemoteUserBackend
   header: HTTP_REMOTE_USER
   autoCreateUser: true
+  autoCreateGroups: false
   defaultGroups: []
   defaultPermissions: {}
   groupSyncEnabled: false


### PR DESCRIPTION
This PR adds the option `REMOTE_AUTH_AUTO_CREATE_GROUPS` which is useful for while using remote authentication.

All options are documented [here](https://docs.netbox.dev/en/stable/configuration/remote-authentication/#remote_auth_auto_create_groups).