### PR TITLE
Allow PodIP to be included as part of the ALLOWED_HOSTS setting

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -65,6 +65,10 @@ data:
                                      in REDIS['caching']['SENTINELS']]
     {{- end }}
 
+    {{- if .Values.allowedHostsIncludesPodIp }}
+    ALLOWED_HOSTS.append(os.getenv("POD_IP"))
+    {{- end }}
+
   netbox.yaml: |
     ALLOWED_HOSTS: {{ toJson .Values.allowedHosts }}
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -82,6 +82,15 @@ spec:
             {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+
+            {{- if .Values.allowedHostsIncludesPodIp }}
+             - name: POD_IP
+               valueFrom:
+                 fieldRef:
+                   apiVersion: v1
+                   fieldPath: status.podIP
+            {{- end }}
+
           ports:
             - name: http
               containerPort: 8080

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,10 @@ skipStartupScripts: true
 allowedHosts:
   - '*'
 
+# Include Pod IP in list of allowed hosts by providing it as the 'POD_IP' envvar
+# at runtime, which is then used in the configuration.py.
+allowedHostsIncludesPodIP: true
+
 # Specify one or more name and email address tuples representing NetBox
 # administrators. These people will be notified of application errors (assuming
 # correct email settings are provided).


### PR DESCRIPTION
To simplify Prometheus metrics gathering (refs issue #166).