### PR TITLE
Support Netbox Docker image v4

### DIFF
--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -121,9 +121,8 @@ spec:
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 10 }}
         {{- else if .Values.livenessProbe.enabled }}
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 10 }}
-          httpGet:
-            path: /status/applications/netbox/processes/running
-            port: nginx-status
+          tcpSocket:
+            port: 8000
         {{- end }}
         {{- if .Values.customReadinessProbe }}
         readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 10 }}


### PR DESCRIPTION
Closes #1032 

Todo:
- [ ] Cleanup Nginx Unit refs
- [ ] Set Granian config customization (https://github.com/netbox-community/netbox-docker/blob/c60defe0e6e814c3626a36528ad683a5df9b6ecc/docker/granian.py)
- [ ] Enable metrics (`GRANIAN_METRICS_ENABLED`)
- [ ] Consider metrics endpoint as a liveness probe