### PR TITLE
feat(plugins): Support bootstrap configuration

### DIFF
--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -179,6 +179,7 @@ The following table lists the configurable parameters for this chart and their d
 | `dateTimeFormat`                                | Django date format for long-form date and time strings              | `"N j, Y g:i a"`                             |
 | `shortDateTimeFormat`                           | Django date format for short-form date and time strongs             | `"Y-m-d H:i"`                                |
 | `extraConfig`                                   | Additional NetBox configuration (see `values.yaml`)                 | `[]`                                         |
+| `extraBootstrapConfig`                          | Additional config to add to configuration.py. Normally used for config that is required before Plugins are imported. | `""`  |
 | `secretKey`                                     | Django secret key used for sessions and password reset tokens       | `""` (generated)                             |
 | `existingSecret`                                | Use an existing Kubernetes `Secret` for secret values (see below)   | `""` (use individual chart values)           |
 | `postgresql.enabled`                            | Deploy PostgreSQL using bundled Bitnami PostgreSQL chart            | `true`                                       |

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -10,6 +10,9 @@ metadata:
 data:
   configuration.py: |-
     {{ .Files.Get "files/configuration.py" | nindent 4 }}
+    {{- if .Values.extraBootstrapConfig }}
+    {{ tpl .Values.extraBootstrapConfig . | nindent 4 }}
+    {{- end }}
 
   netbox.yaml: |-
     ALLOWED_HOSTS: {{ toJson .Values.allowedHosts }}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -466,6 +466,10 @@
     "extraConfig": {
       "type": "array"
     },
+    "extraBootstrapConfig": {
+      "type": "string",
+      "default": ""
+    },
     "extraDeploy": {
       "type": ["array", "string"]
     },

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -467,6 +467,13 @@ shortDateTimeFormat: "Y-m-d H:i"
 #       optional: false
 extraConfig: []
 
+## Extra Bootstrap configuration
+# This is additional configuration to be added to the configuration.py file before plugins are imported.
+# This is useful for bootstrapping NetBox with custom settings that may be required by plugins.
+# The values is evaluated as a template, so you can use it to load values from ConfigMaps and Secrets.
+# The value is appended to the configuration.py file, and needs to contain valid pyhton code.
+extraBootstrapConfig: ""
+
 # If provided, this should be a 50+ character string of random characters. It
 # will be randomly generated if left blank.
 # You can also use an existing secret with "secret_key" instead of "secretKey"

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -471,7 +471,7 @@ extraConfig: []
 # This is additional configuration to be added to the configuration.py file before plugins are imported.
 # This is useful for bootstrapping NetBox with custom settings that may be required by plugins.
 # The values is evaluated as a template, so you can use it to load values from ConfigMaps and Secrets.
-# The value is appended to the configuration.py file, and needs to contain valid pyhton code.
+# The value is appended to the configuration.py file, and needs to contain valid python code.
 extraBootstrapConfig: ""
 
 # If provided, this should be a 50+ character string of random characters. It


### PR DESCRIPTION
This PR solves the need for Python configuration that is executed before plugins are imported. The configuration is appended to `configuration.py`, through the key `extraBootstrapConfig`. This PR is created in relevance to an existing issue.

Fixes #1043 