### PR TITLE
feat: add support for `API_TOKEN_PEPPERS` via secret or env var

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.0.27
+version: 8.1.0
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.5.7"
 type: application

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -180,7 +180,7 @@ The following table lists the configurable parameters for this chart and their d
 | `shortDateTimeFormat`                           | Django date format for short-form date and time strongs             | `"Y-m-d H:i"`                                |
 | `extraConfig`                                   | Additional NetBox configuration (see `values.yaml`)                 | `[]`                                         |
 | `secretKey`                                     | Django secret key used for sessions and password reset tokens       | `""` (generated)                             |
-| `apiTokenPepper1`                               | Random string of characters used as an API token pepper             | `""` (generated)                             |
+| `apiTokenPepper1`                               | Random string of characters used as an API token pepper             | `""`                                         |
 | `existingSecret`                                | Use an existing Kubernetes `Secret` for secret values (see below)   | `""` (use individual chart values)           |
 | `postgresql.enabled`                            | Deploy PostgreSQL using bundled Bitnami PostgreSQL chart            | `true`                                       |
 | `postgresql.auth.username`                      | Username to create for NetBox in bundled PostgreSQL instance        | `netbox`                                     |

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -180,6 +180,7 @@ The following table lists the configurable parameters for this chart and their d
 | `shortDateTimeFormat`                           | Django date format for short-form date and time strongs             | `"Y-m-d H:i"`                                |
 | `extraConfig`                                   | Additional NetBox configuration (see `values.yaml`)                 | `[]`                                         |
 | `secretKey`                                     | Django secret key used for sessions and password reset tokens       | `""` (generated)                             |
+| `apiTokenPepper1`                               | Random string of characters used as an API token pepper             | `""` (generated)                             |
 | `existingSecret`                                | Use an existing Kubernetes `Secret` for secret values (see below)   | `""` (use individual chart values)           |
 | `postgresql.enabled`                            | Deploy PostgreSQL using bundled Bitnami PostgreSQL chart            | `true`                                       |
 | `postgresql.auth.username`                      | Username to create for NetBox in bundled PostgreSQL instance        | `netbox`                                     |
@@ -447,6 +448,7 @@ Type: `kubernetes.io/basic-auth`
 | -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `ldap_bind_password` | Password for LDAP bind DN                                     | If `remoteAuth.enabled` is `true` and `remoteAuth.backend` is `netbox.authentication.LDAPBackend` |
 | `secret_key`         | Django secret key used for sessions and password reset tokens | Yes                                                                                               |
+| `api_token_pepper_1` | API token pepper (Optional, the projected volume will mount an empty file if missing) | No                                                                                                |
 
 ### Email secret (`email.existingSecretName`)
 

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -126,7 +126,7 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.superusers`                         | The list of users that get promoted to Superuser on login           | `[]`                                         |
 | `remoteAuth.staffGroups`                        | The list of groups that promote an remote User to Staff on login    | `[]`                                         |
 | `remoteAuth.staffUsers`                         | The list of users that get promoted to Staff on login               | `[]`                                         |
-| `remoteAuth.groupSeparator`                     | The Seperator upon which `remoteAuth.groupHeader` gets split into individual groups | `\|`                        |
+| `remoteAuth.groupSeparator`                     | The Separator upon which `remoteAuth.groupHeader` gets split into individual groups | `\|`                        |
 | `remoteAuth.ldap.serverUri`                     | see [django-auth-ldap](https://django-auth-ldap.readthedocs.io)     | `""`                                         |
 | `remoteAuth.ldap.startTls`                      | if StarTLS should be used                                           | *see values.yaml*                            |
 | `remoteAuth.ldap.ignoreCertErrors`              | if Certificate errors should be ignored                             | *see values.yaml*                            |
@@ -159,7 +159,7 @@ The following table lists the configurable parameters for this chart and their d
 | `timeFormat`                                    | Django date format for long-form time strings                       | `"g:i a"`                                    |
 | `metrics.granian.enabled`                       | Enable Granian metrics                                              | `true`                                       |
 | `metrics.granian.serviceMonitor.enabled`        | Whether to enable a [ServiceMonitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) for Granian metrics | `false`                                      |
-| `metrics.granian.serviceMonitor.additionalLabels`| Additonal labels to apply to the ServiceMonitor                     | `{}`                                         |
+| `metrics.granian.serviceMonitor.additionalLabels`| Additional labels to apply to the ServiceMonitor                     | `{}`                                         |
 | `metrics.granian.serviceMonitor.honorLabels`    | honorLabels chooses the metric's labels on collisions               | `false`                                      |
 | `metrics.granian.serviceMonitor.interval`       | Interval at which metrics should be scraped                         | `""`                                         |
 | `metrics.granian.serviceMonitor.scrapeTimeout`  | Timeout duration for scraping metrics                               | `""`                                         |
@@ -168,7 +168,7 @@ The following table lists the configurable parameters for this chart and their d
 | `metrics.granian.serviceMonitor.selector`       | Prometheus instance selector labels                                 | `{}`                                         |
 | `metrics.enabled`                               | Expose Prometheus metrics at the `/metrics` HTTP endpoint           | `false`                                      |
 | `metrics.serviceMonitor.enabled`                | Whether to enable a [ServiceMonitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) for Netbox | `false`                                      |
-| `metrics.serviceMonitor.additionalLabels`       | Additonal labels to apply to the ServiceMonitor                     | `{}`                                         |
+| `metrics.serviceMonitor.additionalLabels`       | Additional labels to apply to the ServiceMonitor                     | `{}`                                         |
 | `metrics.serviceMonitor.honorLabels`            | honorLabels chooses the metric's labels on collisions               | `false`                                      |
 | `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                         | `""`                                         |
 | `metrics.serviceMonitor.scrapeTimeout`          | Timeout duration for scraping metrics                               | `""`                                         |

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -67,7 +67,9 @@ REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "cache_passwor
 SECRET_KEY = _read_secret(provided_secret_name, "secret_key")
 
 # Read API_TOKEN_PEPPER_1 from secret or environment variable
-if api_token_pepper := _read_secret(provided_secret_name, "api_token_pepper_1", os.getenv("API_TOKEN_PEPPER_1", "")):
+if api_token_pepper := _read_secret(
+    provided_secret_name, "api_token_pepper_1", os.getenv("API_TOKEN_PEPPER_1", "")
+):
     API_TOKEN_PEPPERS.update({1: api_token_pepper})
 
 # Post-process certain values

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -36,7 +36,9 @@ def _load_yaml() -> None:
         _deep_merge(config, globals())
 
 
-def _read_secret(secret_name: str, secret_key: str, default: str | None = None) -> str | None:
+def _read_secret(
+    secret_name: str, secret_key: str, default: str | None = None
+) -> str | None:
     """Read secret from file"""
     try:
         secret = open(
@@ -75,8 +77,12 @@ if api_token_pepper := _read_secret(
 # Post-process certain values
 CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]
 if "SENTINELS" in REDIS["tasks"]:
-    REDIS["tasks"]["SENTINELS"] = [tuple(x.split(r":")) for x in REDIS["tasks"]["SENTINELS"]]
+    REDIS["tasks"]["SENTINELS"] = [
+        tuple(x.split(r":")) for x in REDIS["tasks"]["SENTINELS"]
+    ]
 if "SENTINELS" in REDIS["caching"]:
-    REDIS["caching"]["SENTINELS"] = [tuple(x.split(r":")) for x in REDIS["caching"]["SENTINELS"]]
+    REDIS["caching"]["SENTINELS"] = [
+        tuple(x.split(r":")) for x in REDIS["caching"]["SENTINELS"]
+    ]
 if ALLOWED_HOSTS_INCLUDES_POD_ID:
     ALLOWED_HOSTS.append(os.getenv("POD_IP"))

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -54,6 +54,7 @@ CORS_ORIGIN_REGEX_WHITELIST = []
 DATABASES = {}
 EMAIL = {}
 REDIS = {}
+API_TOKEN_PEPPERS = {}
 
 _load_yaml()
 
@@ -64,6 +65,10 @@ EMAIL["PASSWORD"] = _read_secret(provided_secret_name, "email_password")
 REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "tasks_password")
 REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "cache_password")
 SECRET_KEY = _read_secret(provided_secret_name, "secret_key")
+
+# Matching the logic from _ to read API_TOKEN_PEPPER_1 from environment variables
+if api_token_pepper := _read_secret('api_token_pepper_1', environ.get('API_TOKEN_PEPPER_1', '')):
+    API_TOKEN_PEPPERS.update({1: api_token_pepper})
 
 # Post-process certain values
 CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -66,8 +66,8 @@ REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "tasks_password"
 REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "cache_password")
 SECRET_KEY = _read_secret(provided_secret_name, "secret_key")
 
-# Matching the logic from _ to read API_TOKEN_PEPPER_1 from environment variables
-if api_token_pepper := _read_secret('api_token_pepper_1', environ.get('API_TOKEN_PEPPER_1', '')):
+# Read API_TOKEN_PEPPER_1 from secret or environment variable
+if api_token_pepper := _read_secret(provided_secret_name, "api_token_pepper_1", os.getenv("API_TOKEN_PEPPER_1", "")):
     API_TOKEN_PEPPERS.update({1: api_token_pepper})
 
 # Post-process certain values

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -36,9 +36,7 @@ def _load_yaml() -> None:
         _deep_merge(config, globals())
 
 
-def _read_secret(
-    secret_name: str, secret_key: str, default: str | None = None
-) -> str | None:
+def _read_secret(secret_name: str, secret_key: str, default: str | None = None) -> str | None:
     """Read secret from file"""
     try:
         secret = open(
@@ -77,12 +75,8 @@ if api_token_pepper := _read_secret(
 # Post-process certain values
 CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]
 if "SENTINELS" in REDIS["tasks"]:
-    REDIS["tasks"]["SENTINELS"] = [
-        tuple(x.split(r":")) for x in REDIS["tasks"]["SENTINELS"]
-    ]
+    REDIS["tasks"]["SENTINELS"] = [tuple(x.split(r":")) for x in REDIS["tasks"]["SENTINELS"]]
 if "SENTINELS" in REDIS["caching"]:
-    REDIS["caching"]["SENTINELS"] = [
-        tuple(x.split(r":")) for x in REDIS["caching"]["SENTINELS"]
-    ]
+    REDIS["caching"]["SENTINELS"] = [tuple(x.split(r":")) for x in REDIS["caching"]["SENTINELS"]]
 if ALLOWED_HOSTS_INCLUDES_POD_ID:
     ALLOWED_HOSTS.append(os.getenv("POD_IP"))

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -138,6 +138,12 @@ spec:
                     path: ldap_bind_password
                   {{- end }}
               - secret:
+                  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
+                  optional: true
+                  items:
+                  - key: api_token_pepper_1
+                    path: api_token_pepper_1
+              - secret:
                   name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.existingSecret .Values.email.existingSecretName) "defaultNameSuffix" "config" "context" $) }}
                   items:
                   - key: {{ include "netbox.email.secretKey" . | quote }}

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -228,6 +228,12 @@ spec:
                 path: ldap_bind_password
               {{- end }}
           - secret:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
+              optional: true
+              items:
+              - key: api_token_pepper_1
+                path: api_token_pepper_1
+          - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.existingSecret .Values.email.existingSecretName) "defaultNameSuffix" "config" "context" $) }}
               items:
               - key: {{ include "netbox.email.secretKey" . | quote }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -14,8 +14,8 @@ data:
   {{- if not .Values.email.existingSecretName }}
   email_password: {{ .Values.email.password | b64enc | quote }}
   {{- end }}
-  secret_key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "secret_key" "providedValues" (list "secretKey") "context" $) }}
-  api_token_pepper_1: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "api_token_pepper_1" "providedValues" (list "apiTokenPepper1") "context" $) }}
+  secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc | quote }}
+  api_token_pepper_1: {{ .Values.apiTokenPepper1 | default (randAscii 60) | b64enc | quote }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{- end }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -15,6 +15,7 @@ data:
   email_password: {{ .Values.email.password | b64enc | quote }}
   {{- end }}
   secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc | quote }}
+  api_token_pepper_1: {{ .Values.apiTokenPepper1 | default (randAscii 60) | b64enc | quote }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{- end }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -15,16 +15,7 @@ data:
   email_password: {{ .Values.email.password | b64enc | quote }}
   {{- end }}
   secret_key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "secret_key" "providedValues" (list "secretKey") "context" $) }}
-  {{- $pepper := .Values.apiTokenPepper1 }}
-  {{- if not $pepper }}
-    {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $))) }}
-    {{- if and $secretObj $secretObj.data (hasKey $secretObj.data "api_token_pepper_1") }}
-      {{- $pepper = (index $secretObj.data "api_token_pepper_1" | b64dec) }}
-    {{- else }}
-      {{- $pepper = randAscii 60 }}
-    {{- end }}
-  {{- end }}
-  api_token_pepper_1: {{ $pepper | b64enc | quote }}
+  api_token_pepper_1: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "api_token_pepper_1" "providedValues" (list "apiTokenPepper1") "context" $) }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{- end }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -14,8 +14,8 @@ data:
   {{- if not .Values.email.existingSecretName }}
   email_password: {{ .Values.email.password | b64enc | quote }}
   {{- end }}
-  secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc | quote }}
-  api_token_pepper_1: {{ .Values.apiTokenPepper1 | default (randAscii 60) | b64enc | quote }}
+  secret_key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "secret_key" "providedValues" (list "secretKey") "context" $) }}
+  api_token_pepper_1: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "api_token_pepper_1" "providedValues" (list "apiTokenPepper1") "context" $) }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{- end }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -15,7 +15,16 @@ data:
   email_password: {{ .Values.email.password | b64enc | quote }}
   {{- end }}
   secret_key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "secret_key" "providedValues" (list "secretKey") "context" $) }}
-  api_token_pepper_1: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "api_token_pepper_1" "providedValues" (list "apiTokenPepper1") "context" $) }}
+  {{- $pepper := .Values.apiTokenPepper1 }}
+  {{- if not $pepper }}
+    {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $))) }}
+    {{- if and $secretObj $secretObj.data (hasKey $secretObj.data "api_token_pepper_1") }}
+      {{- $pepper = (index $secretObj.data "api_token_pepper_1" | b64dec) }}
+    {{- else }}
+      {{- $pepper = randAscii 60 }}
+    {{- end }}
+  {{- end }}
+  api_token_pepper_1: {{ $pepper | b64enc | quote }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{- end }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -15,7 +15,9 @@ data:
   email_password: {{ .Values.email.password | b64enc | quote }}
   {{- end }}
   secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc | quote }}
-  api_token_pepper_1: {{ .Values.apiTokenPepper1 | default (randAscii 60) | b64enc | quote }}
+  {{- if .Values.apiTokenPepper1 }}
+  api_token_pepper_1: {{ .Values.apiTokenPepper1 | b64enc | quote }}
+  {{- end }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{- end }}

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -164,6 +164,12 @@ spec:
                 path: ldap_bind_password
               {{- end }}
           - secret:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
+              optional: true
+              items:
+              - key: api_token_pepper_1
+                path: api_token_pepper_1
+          - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.existingSecret .Values.email.existingSecretName) "defaultNameSuffix" "config" "context" $) }}
               items:
               - key: {{ include "netbox.email.secretKey" . | quote }}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1291,6 +1291,9 @@
     "secretKey": {
       "type": "string"
     },
+    "apiTokenPepper1": {
+      "type": "string"
+    },
     "securityContext": {
       "properties": {
         "allowPrivilegeEscalation": {

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -478,7 +478,7 @@ secretKey: ""
 # https://netboxlabs.com/docs/netbox/configuration/required-parameters/#api_token_peppers
 # You can also use an existing secret with "api_token_pepper_1" instead of "apiTokenPepper1"
 # See `existingSecret` for details
-# Alternativley, you can provide `API_TOKEN_PEPPER_1` as an environment variable
+# Alternatively, you can provide `API_TOKEN_PEPPER_1` as an environment variable
 # with `extraEnvVarsSecret`
 apiTokenPepper1: ""
 

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -473,9 +473,20 @@ extraConfig: []
 # See `existingSecret` for details
 secretKey: ""
 
+# If provided, this should be a 50+ character string of random characters.
+# It will be randomly generated if left blank.
+# https://netboxlabs.com/docs/netbox/configuration/required-parameters/#api_token_peppers
+# You can also use an existing secret with "api_token_pepper_1" instead of "apiTokenPepper1"
+# See `existingSecret` for details
+# Alternativley, you can provide `API_TOKEN_PEPPER_1` as an environment variable
+# with `extraEnvVarsSecret`
+apiTokenPepper1: ""
+
 ## Provide passwords using existing secret
 # If set, this Secret must contain the following keys:
 # - secret_key: session encryption token (50+ random characters)
+# It can optionally contain (the projected volume is optional, allowing a fail-safe approach):
+# - api_token_pepper_1: API token pepper (50+ random characters)
 existingSecret: ""
 
 ## @section Deployment parameters

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -942,7 +942,7 @@ ingress:
     - host: chart-example.local
       paths:
         # You can manually specify the service name and service port if
-        # required. This could be useful if for exemple you are using the AWS
+        # required. This could be useful if for example you are using the AWS
         # ALB Ingress Controller and want to set up automatic SSL redirect.
         # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/#redirect-traffic-from-http-to-https
         # - path: /*

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -474,7 +474,6 @@ extraConfig: []
 secretKey: ""
 
 # If provided, this should be a 50+ character string of random characters.
-# It will be randomly generated if left blank.
 # https://netboxlabs.com/docs/netbox/configuration/required-parameters/#api_token_peppers
 # You can also use an existing secret with "api_token_pepper_1" instead of "apiTokenPepper1"
 # See `existingSecret` for details


### PR DESCRIPTION
NetBox 4.5 added `API_TOKEN_PEPPERS` for token v2. 

This PR adds support for `API_TOKEN_PEPPERS` by either reading `api_token_pepper_1` from the provided secret, or falling back to the `API_TOKEN_PEPPER_1` environment variable. 

This tries to follow what was added in `netbox-docker`: <https://github.com/netbox-community/netbox-docker/blob/c6cd7ef2de050803b986c17765b8aa54282dbb3e/configuration/configuration.py#L119-L121>
Commit: https://github.com/netbox-community/netbox-docker/commit/1f0ef020a9d1372f6786d55c907870a46493a818

If neither input is provided, this should continue evaluating to an empty `API_TOKEN_PEPPERS`, which, at least in NetBox `4.5`, is acceptable. 

Changes:
- Adds a few methods to set `API_TOKEN_PEPPERS`
   - Add to values file as `apiTokenPepper1`, similar to the existing secret key
   - Include within `existingSecret` as `api_token_pepper_1`
   - In situations where `existingSecret` is used but does not contain a pepper value, the projected volume uses `optional: true` which will mount an empty file
      - In this case, the `configuration.py` will lastly check for an env var `API_TOKEN_PEPPER_1` that could be provided with `extraEnvVarsSecret`
      - And if not provided, this should not block NetBox from starting, unless default behavior changes in future versions
- Increments chart version to `8.2.0`
- Fix some minor spelling to get super lint passing
