### PR TITLE
fix(ci): don't pass GITHUB_TOKEN to super-linter

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -9,6 +9,7 @@ name: Lint Status
 
 on:
   workflow_run:
+    # Must match the `name:` in lint.yml exactly.
     workflows: ["Lint Code Base"]
     types: [completed]
 
@@ -26,17 +27,42 @@ jobs:
         with:
           script: |
             const run = context.payload.workflow_run;
-            const state = run.conclusion === 'success' ? 'success'
-              : run.conclusion === 'cancelled' ? 'error'
-              : 'failure';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: run.head_sha,
-              state,
-              target_url: run.html_url,
-              description: run.conclusion === 'success'
-                ? 'Lint passed'
-                : `Lint ${run.conclusion} — see workflow run for details`,
-              context: 'Lint / Super-Linter',
-            });
+            if (!run || !run.head_sha) {
+              core.setFailed('workflow_run payload missing or has no head_sha');
+              return;
+            }
+            if (!run.conclusion) {
+              core.setFailed(`workflow_run ${run.id} has no conclusion`);
+              return;
+            }
+
+            let state;
+            let description;
+            if (run.conclusion === 'success') {
+              state = 'success';
+              description = 'Lint passed';
+            } else if (run.conclusion === 'cancelled' || run.conclusion === 'timed_out') {
+              state = 'error';
+              description = `Lint ${run.conclusion} — see workflow run for details`;
+            } else {
+              state = 'failure';
+              description = `Lint ${run.conclusion} — see workflow run for details`;
+            }
+
+            try {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: run.head_sha,
+                state,
+                target_url: run.html_url,
+                description,
+                context: 'Lint / Super-Linter',
+              });
+            } catch (error) {
+              core.error(
+                `Failed to post status for ${run.head_sha}: `
+                + `${error.status ?? 'unknown'} - ${error.message}`
+              );
+              throw error;
+            }

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -8,6 +8,9 @@
 name: Lint Status
 
 on:
+  # zizmor: ignore[dangerous-triggers] -- intentional; this is the secure
+  # two-workflow pattern for posting status on fork PRs. The workflow only
+  # calls createCommitStatus with data from the workflow_run payload.
   workflow_run:
     # Must match the `name:` in lint.yml exactly.
     workflows: ["Lint Code Base"]

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -1,0 +1,42 @@
+# https://docs.github.com/actions
+#
+# Posts a commit status after the Lint workflow completes.
+# Runs in the base repo context (full token permissions),
+# so it works correctly for fork PRs where the lint workflow
+# itself has only read access.
+
+name: Lint Status
+
+on:
+  workflow_run:
+    workflows: ["Lint Code Base"]
+    types: [completed]
+
+permissions:
+  statuses: write
+
+jobs:
+  report:
+    name: Report Lint Status
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Update commit status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const state = run.conclusion === 'success' ? 'success'
+              : run.conclusion === 'cancelled' ? 'error'
+              : 'failure';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: run.head_sha,
+              state,
+              target_url: run.html_url,
+              description: run.conclusion === 'success'
+                ? 'Lint passed'
+                : `Lint ${run.conclusion} — see workflow run for details`,
+              context: 'Lint / Super-Linter',
+            });

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,8 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
+          MULTI_STATUS: false
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           FIX_MARKDOWN_PRETTIER: false
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_MARKDOWN_PRETTIER: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 # https://docs.github.com/actions
+# NOTE: lint-report.yml triggers on this workflow by name.
+# If you rename it, update lint-report.yml to match.
 
 name: Lint Code Base
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   packages: read
-  statuses: write
 
 jobs:
   build:
@@ -29,7 +28,6 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FIX_MARKDOWN_PRETTIER: false
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_MARKDOWN_PRETTIER: false

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.0.31
+version: 8.0.32
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.5.7"
 type: application


### PR DESCRIPTION
fork PRs get a restricted `GITHUB_TOKEN` that causes super-linter to fail on auth rather than actual lint errors (see #1135).

this splits the lint workflow into two parts:
- `lint.yml` runs super-linter without `GITHUB_TOKEN` — the check run pass/fail is automatic
- `lint-report.yml` triggers on `workflow_run` completion and posts a commit status from the base repo context with full permissions

this is the [recommended secure pattern](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) for workflows that need write access on fork PRs.