### PR TITLE
Allow banners and maintenance mode to be managed from web UI

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.0.32
+version: 8.1.0
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.5.7"
 type: application

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -87,7 +87,9 @@ data:
     LOGIN_REQUIRED: {{ toJson .Values.loginRequired }}
     LOGIN_TIMEOUT: {{ int .Values.loginTimeout }}
     LOGOUT_REDIRECT_URL: {{ .Values.logoutRedirectUrl | quote }}
-    {{ if ne nil .Values.maintenanceMode }}MAINTENANCE_MODE: {{ toJson .Values.maintenanceMode }}{{ end }}
+    {{- if ne nil .Values.maintenanceMode }}
+    MAINTENANCE_MODE: {{ toJson .Values.maintenanceMode }}
+    {{- end }}
     MAPS_URL: {{ .Values.mapsUrl | quote }}
     MAX_PAGE_SIZE: {{ int .Values.maxPageSize }}
     MEDIA_ROOT: /opt/netbox/netbox/media

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -48,9 +48,9 @@ data:
     ALLOW_TOKEN_RETRIEVAL: {{ toJson .Values.allowTokenRetrieval }}
     AUTH_PASSWORD_VALIDATORS: {{ toJson .Values.authPasswordValidators }}
     ALLOWED_URL_SCHEMES: {{ toJson .Values.allowedUrlSchemes }}
-    BANNER_TOP: {{ .Values.banner.top | quote }}
-    BANNER_BOTTOM: {{ .Values.banner.bottom | quote }}
-    BANNER_LOGIN: {{ .Values.banner.login | quote }}
+    {{- range $k, $v := .Values.banner }}
+    BANNER_{{ upper $k }}: {{ $v | quote }}
+    {{- end }}
     BASE_PATH: {{ .Values.basePath | quote }}
     CHANGELOG_RETENTION: {{ int .Values.changelogRetention }}
     CUSTOM_VALIDATORS: {{ toJson .Values.customValidators }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -87,7 +87,7 @@ data:
     LOGIN_REQUIRED: {{ toJson .Values.loginRequired }}
     LOGIN_TIMEOUT: {{ int .Values.loginTimeout }}
     LOGOUT_REDIRECT_URL: {{ .Values.logoutRedirectUrl | quote }}
-    MAINTENANCE_MODE: {{ toJson .Values.maintenanceMode }}
+    {{ if ne nil .Values.maintenanceMode }}MAINTENANCE_MODE: {{ toJson .Values.maintenanceMode }}{{ end }}
     MAPS_URL: {{ .Values.mapsUrl | quote }}
     MAX_PAGE_SIZE: {{ int .Values.maxPageSize }}
     MEDIA_ROOT: /opt/netbox/netbox/media

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -234,16 +234,16 @@
     "banner": {
       "properties": {
         "bottom": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "login": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "top": {
-          "type": "string"
+          "type": ["string", "null"]
         }
       },
-      "type": "object"
+      "type": ["object", "null"]
     },
     "basePath": {
       "type": "string"

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -829,7 +829,7 @@
       "type": "string"
     },
     "maintenanceMode": {
-      "type": "boolean"
+      "type": ["boolean", "null"]
     },
     "mapsUrl": {
       "type": "string"

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -935,7 +935,7 @@ ingress:
     - host: chart-example.local
       paths:
         # You can manually specify the service name and service port if
-        # required. This could be useful if for exemple you are using the AWS
+        # required. This could be useful if for example you are using the AWS
         # ALB Ingress Controller and want to set up automatic SSL redirect.
         # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/#redirect-traffic-from-http-to-https
         # - path: /*

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -134,6 +134,9 @@ allowedUrlSchemes:
   - vnc
   - xmpp
 
+# Setting this to null will allow all banners to be managed from the web interface.
+# Setting any individual banner (top/bottom/login) under this key to null with allow
+# to manage it from the web interface.
 banner:
   # Optionally display a persistent banner at the top and/or bottom of every
   # page. HTML is allowed.

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -299,7 +299,8 @@ loginTimeout: 1209600
 logoutRedirectUrl: home
 
 # Setting this to True will display a "maintenance mode" banner at the top of
-# every page.
+# every page. Setting this to null will allow to manage maintenance mode from
+# the web interface.
 maintenanceMode: false
 
 # The URL to use when mapping physical addresses or GPS coordinates


### PR DESCRIPTION
## What this PR does

Allow to set all banners, any individual banner and/or maintenance mode to `null` value. When set to `null`, instead of being defined as empty strings in the ConfigMap, the keys are completely omitted. Therefore, instead of being "locked" in `/core/config-revisions/add/` in the web UI, they are editable.

## What problem it solves

Without this, updating a banner requires a Netbox restart, so we cannot notify users that a restart is going to happen. Also, just updating a banner in Helm Values and re-applying it makes Netbox AND the workers to rollout, so ongoing background tasks may get killed.

IMHO, it is better to allow operators to "hot" update banners to properly communicate before any worker rollout, Netbox upgrades, etc., without having to restart the whole stack.

## Example usage

```yaml
# All banners are absent from the ConfigMap, and they are all manageable from the web UI
banner: null

# Login banner cannot be changed from the UI, but bottom and top banners can
banner:
  login: ""  # optional, it is already set in values.yaml
  top: null
  bottom: null

# Maintenance mode can be configured in the UI
maintenanceMode: null
```