### PR TITLE
fix: switch source links so that renovate can find changelogs

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.0.32
+version: 8.0.33
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.5.7"
 type: application
@@ -9,8 +9,8 @@ description: IP address management (IPAM) and data center infrastructure managem
 home: https://netbox.dev/
 icon: https://raw.githubusercontent.com/netbox-community/netbox/main/docs/netbox_logo_light.svg
 sources:
-  - https://github.com/netbox-community/netbox
   - https://github.com/netbox-community/netbox-chart
+  - https://github.com/netbox-community/netbox
 maintainers:
   - name: netbox-community
     url: https://github.com/netbox-community


### PR DESCRIPTION
This allows renovate to properly detect the source repo. Those sources will be checked in defined order.

https://github.com/renovatebot/renovate/blob/8c1899d0c15793116a4956398f3965c0a658d3cf/lib/modules/datasource/docker/common.ts#L351-L379