### PR TITLE
feat(netbox): add API_TOKEN_PEPPERS support

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.1.11
+version: 8.2.0
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.5.8"
 type: application

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -3,6 +3,7 @@ This file serves as a base configuration for Netbox
 https://netboxlabs.com/docs/netbox/en/stable/configuration/
 """
 
+import json
 import os
 import re
 from pathlib import Path
@@ -47,7 +48,7 @@ def _read_secret(secret_name: str, secret_key: str, default: str | None = None) 
     except EnvironmentError:
         return default
     with secret:
-        return secret.readline().strip()
+        return secret.read().strip()
 
 
 CORS_ORIGIN_REGEX_WHITELIST = []
@@ -64,6 +65,18 @@ EMAIL["PASSWORD"] = _read_secret(provided_secret_name, "email_password")
 REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "tasks_password")
 REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "cache_password")
 SECRET_KEY = _read_secret(provided_secret_name, "secret_key")
+
+# Read API token peppers from secret (JSON with integer or string keys)
+_peppers_raw = _read_secret(provided_secret_name, "api_token_peppers")
+if _peppers_raw:
+    try:
+        API_TOKEN_PEPPERS = {int(k): v for k, v in json.loads(_peppers_raw).items()}
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        raise ValueError(
+            f"Invalid api_token_peppers secret: expected a JSON object mapping numeric "
+            f'string keys to string values, e.g. {{"1": "random-string..."}}. '
+            f"Keys are converted to integers at load time. Error: {exc}"
+        ) from exc
 
 # Post-process certain values
 CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -178,6 +178,30 @@ Volume mounts for .Values.extraConfig entries
 {{- end }}
 
 {{/*
+Generate the api_token_peppers secret value.
+Returns a base64-encoded, quoted JSON object.
+
+Priority:
+  1. User-provided apiTokenPeppers from values.yaml (always wins for rotation)
+  2. Existing secret value (preserved across upgrades via lookup)
+  3. Auto-generated single pepper {"1": "<random 50 chars>"}
+*/}}
+{{- define "netbox.apiTokenPeppers.secret" -}}
+{{- if not (empty .Values.apiTokenPeppers) -}}
+  {{- .Values.apiTokenPeppers | toJson | b64enc | quote }}
+{{- else -}}
+  {{- $secretName := include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $) -}}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "common.names.namespace" .) $secretName).data -}}
+  {{- if and $existingSecret (hasKey $existingSecret "api_token_peppers") -}}
+    {{- index $existingSecret "api_token_peppers" | quote }}
+  {{- else -}}
+    {{- $pepper := randAlphaNum 50 -}}
+    {{- dict "1" $pepper | toJson | b64enc | quote }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Compile all warnings into a single message.
 */}}
 {{- define "netbox.validateValues" -}}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -138,6 +138,12 @@ spec:
                     path: ldap_bind_password
                   {{- end }}
               - secret:
+                  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
+                  optional: true
+                  items:
+                  - key: api_token_peppers
+                    path: api_token_peppers
+              - secret:
                   name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.existingSecret .Values.email.existingSecretName) "defaultNameSuffix" "config" "context" $) }}
                   items:
                   - key: {{ include "netbox.email.secretKey" . | quote }}

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -228,6 +228,12 @@ spec:
                 path: ldap_bind_password
               {{- end }}
           - secret:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
+              optional: true
+              items:
+              - key: api_token_peppers
+                path: api_token_peppers
+          - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.existingSecret .Values.email.existingSecretName) "defaultNameSuffix" "config" "context" $) }}
               items:
               - key: {{ include "netbox.email.secretKey" . | quote }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -14,7 +14,8 @@ data:
   {{- if not .Values.email.existingSecretName }}
   email_password: {{ .Values.email.password | b64enc | quote }}
   {{- end }}
-  secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc | quote }}
+  secret_key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $)) "key" "secret_key" "providedValues" (list "secretKey") "length" 60 "strong" true "failOnNew" false "context" $) }}
+  api_token_peppers: {{ include "netbox.apiTokenPeppers.secret" . }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{- end }}

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -164,6 +164,12 @@ spec:
                 path: ldap_bind_password
               {{- end }}
           - secret:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
+              optional: true
+              items:
+              - key: api_token_peppers
+                path: api_token_peppers
+          - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.existingSecret .Values.email.existingSecretName) "defaultNameSuffix" "config" "context" $) }}
               items:
               - key: {{ include "netbox.email.secretKey" . | quote }}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1288,6 +1288,16 @@
       },
       "type": "object"
     },
+    "apiTokenPeppers": {
+      "type": "object",
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "string",
+          "minLength": 50
+        }
+      },
+      "additionalProperties": false
+    },
     "secretKey": {
       "type": "string"
     },

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -477,9 +477,25 @@ extraConfig: []
 # See `existingSecret` for details
 secretKey: ""
 
+# API token peppers used for v2 API token HMAC signing.
+# https://netboxlabs.com/docs/netbox/configuration/required-parameters/#api_token_peppers
+# Keys must be integers (0-32767), values must be 50+ character random strings.
+# If empty, one pepper (key 1) will be auto-generated and preserved across upgrades.
+# New tokens always use the highest-numbered pepper. To rotate, add a new
+# higher-numbered entry; do NOT remove old entries or existing tokens will break.
+# You can also use an existing secret with "api_token_peppers" instead.
+# See `existingSecret` for details.
+# apiTokenPeppers:
+#   1: "<50+ random characters>"
+#   2: "<50+ random characters>"
+apiTokenPeppers: {}
+
 ## Provide passwords using existing secret
 # If set, this Secret must contain the following keys:
 # - secret_key: session encryption token (50+ random characters)
+# It may optionally contain:
+# - api_token_peppers: JSON object mapping integer pepper IDs to 50+ char strings,
+#   e.g. {"1": "abcdef..."}. Keys may be integers or strings (converted at runtime).
 existingSecret: ""
 
 ## @section Deployment parameters


### PR DESCRIPTION
adds `apiTokenPeppers` as a `values.yaml` field. `configuration.py` ensures keys are always integers.

Also fixes secretKey to use `common.secrets.passwords.manage` so it's preserved across upgrades.

fixes #1021
closes #1135 