### PR TITLE
Fix NetBox translation setting

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.2.17
+version: 8.2.18
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.6.1"
 type: application

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -126,7 +126,7 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.superusers`                         | The list of users that get promoted to Superuser on login           | `[]`                                         |
 | `remoteAuth.staffGroups`                        | The list of groups that promote an remote User to Staff on login    | `[]`                                         |
 | `remoteAuth.staffUsers`                         | The list of users that get promoted to Staff on login               | `[]`                                         |
-| `remoteAuth.groupSeparator`                     | The Seperator upon which `remoteAuth.groupHeader` gets split into individual groups | `\|`                        |
+| `remoteAuth.groupSeparator`                     | The separator upon which `remoteAuth.groupHeader` gets split into individual groups | `\|`                        |
 | `remoteAuth.ldap.serverUri`                     | see [django-auth-ldap](https://django-auth-ldap.readthedocs.io)     | `""`                                         |
 | `remoteAuth.ldap.startTls`                      | if StarTLS should be used                                           | *see values.yaml*                            |
 | `remoteAuth.ldap.ignoreCertErrors`              | if Certificate errors should be ignored                             | *see values.yaml*                            |
@@ -159,7 +159,7 @@ The following table lists the configurable parameters for this chart and their d
 | `timeFormat`                                    | Django date format for long-form time strings                       | `"g:i a"`                                    |
 | `metrics.granian.enabled`                       | Enable Granian metrics                                              | `true`                                       |
 | `metrics.granian.serviceMonitor.enabled`        | Whether to enable a [ServiceMonitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) for Granian metrics | `false`                                      |
-| `metrics.granian.serviceMonitor.additionalLabels`| Additonal labels to apply to the ServiceMonitor                     | `{}`                                         |
+| `metrics.granian.serviceMonitor.additionalLabels`| Additional labels to apply to the ServiceMonitor                    | `{}`                                         |
 | `metrics.granian.serviceMonitor.honorLabels`    | honorLabels chooses the metric's labels on collisions               | `false`                                      |
 | `metrics.granian.serviceMonitor.interval`       | Interval at which metrics should be scraped                         | `""`                                         |
 | `metrics.granian.serviceMonitor.scrapeTimeout`  | Timeout duration for scraping metrics                               | `""`                                         |
@@ -168,7 +168,7 @@ The following table lists the configurable parameters for this chart and their d
 | `metrics.granian.serviceMonitor.selector`       | Prometheus instance selector labels                                 | `{}`                                         |
 | `metrics.enabled`                               | Expose Prometheus metrics at the `/metrics` HTTP endpoint           | `false`                                      |
 | `metrics.serviceMonitor.enabled`                | Whether to enable a [ServiceMonitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) for Netbox | `false`                                      |
-| `metrics.serviceMonitor.additionalLabels`       | Additonal labels to apply to the ServiceMonitor                     | `{}`                                         |
+| `metrics.serviceMonitor.additionalLabels`       | Additional labels to apply to the ServiceMonitor                    | `{}`                                         |
 | `metrics.serviceMonitor.honorLabels`            | honorLabels chooses the metric's labels on collisions               | `false`                                      |
 | `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                         | `""`                                         |
 | `metrics.serviceMonitor.scrapeTimeout`          | Timeout duration for scraping metrics                               | `""`                                         |

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -152,7 +152,7 @@ The following table lists the configurable parameters for this chart and their d
 | `releaseCheck.url`                              | Release check URL (GitHub API URL; see `values.yaml`)               | `null` (disabled by default)                 |
 | `rqDefaultTimeout`                              | Maximum execution time for background tasks, in seconds             | `300` (5 minutes)                            |
 | `sessionCookieName`                             | The name to use for the session cookie                              | `"sessionid"`                                |
-| `enableLocalization`                            | Localization                                                        | `false`                                      |
+| `translationEnabled`                            | Enables language translation for the user interface                 | `true`                                       |
 | `timeZone`                                      | The time zone NetBox will use when dealing with dates and times     | `UTC`                                        |
 | `dateFormat`                                    | Django date format for long-form date strings                       | `"N j, Y"`                                   |
 | `shortDateFormat`                               | Django date format for short-form date strings                      | `"Y-m-d"`                                    |

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -164,7 +164,7 @@ data:
     SCRIPTS_ROOT: /opt/netbox/netbox/scripts
     CSRF_COOKIE_NAME: {{ .Values.csrf.cookieName | quote }}
     SESSION_COOKIE_NAME: {{ .Values.sessionCookieName }}
-    ENABLE_LOCALIZATION: {{ toJson .Values.enableLocalization }}
+    TRANSLATION_ENABLED: {{ toJson .Values.translationEnabled }}
     TIME_ZONE: {{ .Values.timeZone | quote }}
     DATE_FORMAT: {{ .Values.dateFormat | quote }}
     SHORT_DATE_FORMAT: {{ .Values.shortDateFormat | quote }}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -410,9 +410,6 @@
       },
       "type": "object"
     },
-    "enableLocalization": {
-      "type": "boolean"
-    },
     "enforceGlobalUnique": {
       "type": "boolean"
     },
@@ -1574,6 +1571,9 @@
     },
     "topologySpreadConstraints": {
       "type": ["array", "string"]
+    },
+    "translationEnabled": {
+      "type": "boolean"
     },
     "updateStrategy": {
       "properties": {

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -438,11 +438,11 @@ rqDefaultTimeout: 300
 # The name to use for the session cookie.
 sessionCookieName: sessionid
 
-# Localization
-enableLocalization: false
-
 # Time zone (default: UTC)
 timeZone: UTC
+
+# Web UI translation
+translationEnabled: true
 
 # Date/time formatting. See the following link for supported formats:
 # https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date


### PR DESCRIPTION
Since https://github.com/netbox-community/netbox/issues/15752 and NetBox v4.0.0 ENABLE_LOCALIZATION setting was removed.

In https://github.com/netbox-community/netbox/pull/16096 and NetBox v4.0.2 new option to disable translation was added https://netboxlabs.com/docs/netbox/configuration/system/#translation_enabled

This PR changes the old setting to a new setting, which gives the user the ability to disable web UI translation.