### PR TITLE
Fix ambiguous mixed-type JSON Schema definitions

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.3.1
+version: 8.3.2
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.6.1"
 type: application

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -560,15 +560,15 @@
     "housekeeping": {
       "properties": {
         "affinity": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "args": {
           "items": {
@@ -620,37 +620,37 @@
           "type": ["array", "string"]
         },
         "nodeSelector": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "podAnnotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "podLabels": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "podSecurityContext": {
           "properties": {
@@ -768,15 +768,15 @@
     "ingress": {
       "properties": {
         "annotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "className": {
           "type": "string"
@@ -1033,15 +1033,15 @@
           "type": "string"
         },
         "annotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "enabled": {
           "type": "boolean"
@@ -1050,15 +1050,15 @@
           "type": "string"
         },
         "selector": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "size": {
           "type": "string"
@@ -1346,15 +1346,15 @@
           "type": "string"
         },
         "annotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "enabled": {
           "type": "boolean"
@@ -1363,15 +1363,15 @@
           "type": "string"
         },
         "selector": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "size": {
           "type": "string"
@@ -1414,15 +1414,15 @@
           "type": "string"
         },
         "annotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "enabled": {
           "type": "boolean"
@@ -1431,15 +1431,15 @@
           "type": "string"
         },
         "selector": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "size": {
           "type": "string"
@@ -1518,15 +1518,15 @@
     "service": {
       "properties": {
         "annotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "clusterIP": {
           "type": "string"
@@ -1562,15 +1562,15 @@
           "type": "string"
         },
         "sessionAffinityConfig": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "type": {
           "type": "string"
@@ -1581,15 +1581,15 @@
     "serviceAccount": {
       "properties": {
         "annotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "automountServiceAccountToken": {
           "type": "boolean"
@@ -1782,15 +1782,15 @@
     "worker": {
       "properties": {
         "affinity": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "args": {
           "items": {
@@ -1901,37 +1901,37 @@
           "type": ["array", "string"]
         },
         "nodeSelector": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "podAnnotations": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "podLabels": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "podSecurityContext": {
           "properties": {
@@ -1963,15 +1963,15 @@
           "type": "boolean"
         },
         "resources": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {}
-          },
-          {
-            "type": "string"
-          }
-        ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "resourcesPreset": {
           "type": "string"

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -133,8 +133,15 @@
       "type": "array"
     },
     "affinity": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "allowTokenRetrieval": {
       "type": "boolean"
@@ -305,12 +312,26 @@
       "type": ["array", "string"]
     },
     "commonAnnotations": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "commonLabels": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "cors": {
       "properties": {
@@ -338,16 +359,37 @@
       "type": "object"
     },
     "customLivenessProbe": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customReadinessProbe": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customStartupProbe": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customValidators": {
       "properties": {},
@@ -518,8 +560,15 @@
     "housekeeping": {
       "properties": {
         "affinity": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "args": {
           "items": {
@@ -571,16 +620,37 @@
           "type": ["array", "string"]
         },
         "nodeSelector": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "podAnnotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "podLabels": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "podSecurityContext": {
           "properties": {
@@ -698,8 +768,15 @@
     "ingress": {
       "properties": {
         "annotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "className": {
           "type": "string"
@@ -803,8 +880,15 @@
       "type": "integer"
     },
     "lifecycleHooks": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "livenessProbe": {
       "$ref": "#/$defs/probe"
@@ -866,8 +950,15 @@
                   "type": "string"
                 },
                 "selector": {
-                  "properties": {},
-                  "type": ["object", "string"]
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {}
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 }
               },
               "type": "object"
@@ -903,8 +994,15 @@
               "type": "string"
             },
             "selector": {
-              "properties": {},
-              "type": ["object", "string"]
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {}
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "type": "object"
@@ -916,8 +1014,15 @@
       "type": "string"
     },
     "nodeSelector": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "paginateCount": {
       "type": "integer"
@@ -928,8 +1033,15 @@
           "type": "string"
         },
         "annotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "enabled": {
           "type": "boolean"
@@ -938,8 +1050,15 @@
           "type": "string"
         },
         "selector": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "size": {
           "type": "string"
@@ -970,12 +1089,26 @@
       "type": "object"
     },
     "podAnnotations": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "podLabels": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "podSecurityContext": {
       "properties": {
@@ -1213,8 +1346,15 @@
           "type": "string"
         },
         "annotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "enabled": {
           "type": "boolean"
@@ -1223,8 +1363,15 @@
           "type": "string"
         },
         "selector": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "size": {
           "type": "string"
@@ -1239,8 +1386,15 @@
       "type": "object"
     },
     "resources": {
-      "properties": {},
-      "type": ["object", "string"]
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {}
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "resourcesPreset": {
       "type": "string"
@@ -1260,8 +1414,15 @@
           "type": "string"
         },
         "annotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "enabled": {
           "type": "boolean"
@@ -1270,8 +1431,15 @@
           "type": "string"
         },
         "selector": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "size": {
           "type": "string"
@@ -1350,8 +1518,15 @@
     "service": {
       "properties": {
         "annotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "clusterIP": {
           "type": "string"
@@ -1387,8 +1562,15 @@
           "type": "string"
         },
         "sessionAffinityConfig": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "type": {
           "type": "string"
@@ -1399,8 +1581,15 @@
     "serviceAccount": {
       "properties": {
         "annotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "automountServiceAccountToken": {
           "type": "boolean"
@@ -1576,18 +1765,32 @@
       "type": "boolean"
     },
     "updateStrategy": {
-      "properties": {
-        "type": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          }
+        },
+        {
           "type": "string"
         }
-      },
-      "type": ["object", "string"]
+      ]
     },
     "worker": {
       "properties": {
         "affinity": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "args": {
           "items": {
@@ -1698,16 +1901,37 @@
           "type": ["array", "string"]
         },
         "nodeSelector": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "podAnnotations": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "podLabels": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "podSecurityContext": {
           "properties": {
@@ -1739,8 +1963,15 @@
           "type": "boolean"
         },
         "resources": {
-          "properties": {},
-          "type": ["object", "string"]
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "type": "string"
+          }
+        ]
         },
         "resourcesPreset": {
           "type": "string"
@@ -1810,12 +2041,19 @@
           "type": ["array", "string"]
         },
         "updateStrategy": {
-          "properties": {
-            "type": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            {
               "type": "string"
             }
-          },
-          "type": ["object", "string"]
+          ]
         },
         "pdb": {
           "title": "PodDisruptionBudget for NetBox worker",
@@ -1864,8 +2102,15 @@
               "type": "object"
             },
             "resources": {
-              "properties": {},
-              "type": ["object", "string"]
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {}
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "resourcesPreset": {
               "type": "string"


### PR DESCRIPTION
We are using [cdk8s](https://cdk8s.io/) to generate TypeScript definitions for Helm chart values schemas.

Some schemas currently define mixed types like:

```yml
"properties": {},
"type": ["object", "string"]
```

This is ambiguous in JSON Schema semantics, since properties only applies when type is object.

```yml
"oneOf": [
  {
    "type": "object",
    "properties": {}
  },
  {
    "type": "string"
  }
]
```

This improves schema correctness and ensures compatibility with JSON Schema tooling.