### PR TITLE
feat(netbox): expose LDAP group search filter

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 8.3.41
+version: 8.3.42
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.6.6"
 type: application

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -139,6 +139,7 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.ldap.userSearchAttr`                | User attribute name for user search                                 | `sAMAccountName`                             |
 | `remoteAuth.ldap.groupSearchBaseDn`             | base DN for group search                                            | *see values.yaml*                            |
 | `remoteAuth.ldap.groupSearchClass`              | [django-auth-ldap](https://django-auth-ldap.readthedocs.io) for group search | `group`                             |
+| `remoteAuth.ldap.groupSearchFilter`             | LDAP filter used for group search; when empty, a filter is derived from `groupSearchClass` | `""`                  |
 | `remoteAuth.ldap.groupType`                     | see [AUTH_LDAP_GROUP_TYPE](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-group-type) | `GroupOfNamesType` |
 | `remoteAuth.ldap.requireGroupDn`                | DN of a group that is required for login                            | `null`                                       |
 | `remoteAuth.ldap.findGroupPerms`                | see [AUTH_LDAP_FIND_GROUP_PERMS](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-find-group-perms) | true |

--- a/charts/netbox/ci/ldap-values.yaml
+++ b/charts/netbox/ci/ldap-values.yaml
@@ -15,6 +15,7 @@ remoteAuth:
     userSearchAttr: "sAMAccountName"
     groupSearchBaseDn: "dc=example,dc=com"
     groupSearchClass: "group"
+    groupSearchFilter: "(objectClass=group)"
     groupType: "GroupOfNamesType"
     requireGroupDn:
       - "cn=read-only-admin,dc=example,dc=com"

--- a/charts/netbox/docs/auth.md
+++ b/charts/netbox/docs/auth.md
@@ -250,6 +250,35 @@ remoteAuth:
 > In order to use anonymous LDAP binding, set `bindDn` and `bindPassword`
 > to an empty string as in the example above.
 
+### Restricting LDAP Group Search
+
+Use `remoteAuth.ldap.groupSearchFilter` to restrict the LDAP groups
+considered by the LDAP authentication backend. The value must be a valid
+LDAP filter enclosed in parentheses.
+
+When `groupSearchFilter` is empty, the group search falls back to an
+`objectClass` filter derived from `remoteAuth.ldap.groupSearchClass`.
+
+For example:
+
+```yaml
+remoteAuth:
+  ldap:
+    groupSearchBaseDn: OU=Groups,DC=example,DC=com
+    groupSearchFilter: '(&(objectClass=groupOfNames)(|(cn=netbox-users)(cn=netbox-admins)))'
+```
+
+> [!IMPORTANT]
+> This setting restricts LDAP group discovery, not only group mirroring.
+> Ensure that the filter includes all groups referenced by `requireGroupDn`,
+> `isAdminDn`, and `isSuperUserDn`, as well as all LDAP groups whose Django
+> permissions should be resolved when `findGroupPerms` is enabled. When using
+> a nested group type, the filter must also include any intermediate groups
+> needed to resolve nested membership.
+>
+> To restrict only which LDAP groups are mirrored into NetBox, configure
+> `remoteAuth.ldap.mirrorGroups` as a list of group names instead.
+
 ### LDAP Certificate Verification
 
 If you need to specify your own CA certificate, follow the instructions below.

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -193,6 +193,7 @@ data:
     AUTH_LDAP_USER_SEARCH_ATTR: {{ .Values.remoteAuth.ldap.userSearchAttr | quote }}
     AUTH_LDAP_GROUP_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.groupSearchBaseDn | quote }}
     AUTH_LDAP_GROUP_SEARCH_CLASS: {{ .Values.remoteAuth.ldap.groupSearchClass | quote }}
+    AUTH_LDAP_GROUP_SEARCH_FILTER: {{ .Values.remoteAuth.ldap.groupSearchFilter | quote }}
     AUTH_LDAP_GROUP_TYPE: {{ .Values.remoteAuth.ldap.groupType | quote }}
     AUTH_LDAP_FIND_GROUP_PERMS: {{ toJson .Values.remoteAuth.ldap.findGroupPerms }}
     AUTH_LDAP_MIRROR_GROUPS: {{ toJson .Values.remoteAuth.ldap.mirrorGroups }}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1290,6 +1290,9 @@
             "groupSearchClass": {
               "type": "string"
             },
+            "groupSearchFilter": {
+              "type": "string"
+            },
             "groupType": {
               "type": "string"
             },

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -405,6 +405,10 @@ remoteAuth:
     # groupSearchBaseDn: OU=Groups,OU=MyCompany,DC=example,dc=com
     groupSearchBaseDn: ""
     groupSearchClass: group
+    # Optional LDAP group search filter. It must be enclosed in parentheses.
+    # When empty, the filter falls back to "(objectClass=<groupSearchClass>)".
+    # groupSearchFilter: '(&(objectClass=groupOfNames)(|(cn=netbox-users)(cn=netbox-admins)))'
+    groupSearchFilter: ""
     groupType: GroupOfNamesType
     # requireGroupDn:
     #   - CN=Network Configuration Operators,CN=Builtin,DC=example,dc=com


### PR DESCRIPTION
## Summary

Expose the existing `AUTH_LDAP_GROUP_SEARCH_FILTER` LDAP setting through a new `remoteAuth.ldap.groupSearchFilter` Helm value.

The bundled `ldap_config.py` already supports this setting and passes it to `LDAPSearch`, but the chart does not currently render it into `ldap.yaml`.

## Motivation

The chart currently allows configuring the LDAP group search base DN and object class, but not the complete LDAP group search filter.

Exposing the filter allows deployments to use directory-specific LDAP expressions and limit group discovery to groups relevant to NetBox.

This setting controls LDAP group discovery. Deployments that only need to restrict group mirroring can continue to use `remoteAuth.ldap.mirrorGroups`.

## Changes

* Add `remoteAuth.ldap.groupSearchFilter` to `values.yaml`.
* Add the value to `values.schema.json`.
* Render the value as `AUTH_LDAP_GROUP_SEARCH_FILTER` in `ldap.yaml`.
* Add a non-empty filter to the LDAP CI values.
* Document the new setting in the chart README and LDAP authentication documentation.
* Bump the NetBox chart version to `8.3.42`.

## Backward compatibility

The default value is an empty string.

When no custom filter is configured, `ldap_config.py` continues to derive the filter from `remoteAuth.ldap.groupSearchClass`:

```python
f"(objectClass={AUTH_LDAP_GROUP_SEARCH_CLASS})"
```

Existing deployments therefore retain their current LDAP group search behavior.

## Testing

* `helm dependency build charts/netbox`
* `helm lint charts/netbox -f charts/netbox/ci/ldap-values.yaml`
* `jq empty charts/netbox/values.schema.json`
* Rendered `templates/configmap.yaml` with the LDAP CI values.
* Verified that the rendered ConfigMap contains:

```yaml
AUTH_LDAP_GROUP_SEARCH_FILTER: "(objectClass=group)"
```